### PR TITLE
Opioid excel diffs

### DIFF
--- a/lib/helpers/results_helpers.js
+++ b/lib/helpers/results_helpers.js
@@ -319,7 +319,7 @@ module.exports = class ResultsHelpers {
     } else if (result instanceof cql.Interval) {
       return `INTERVAL: ${this.prettyResult(result.low)} - ${this.prettyResult(result.high)}`;
     } else if (result instanceof cql.Code) {
-      return `CODE: ${result.system}: ${result.code}`;
+      return `CODE: ${result.system} ${result.code}`;
     } else if (result instanceof cql.Quantity) {
       let quantityResult = `QUANTITY: ${result.value}`;
       if (result.unit) {

--- a/spec/fixtures/json/patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json
+++ b/spec/fixtures/json/patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json
@@ -1,0 +1,302 @@
+{
+  "birthDatetime": "1958-05-14T04:00:00.000-04:00",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "dataElements": [
+    {
+      "admissionSource": null,
+      "authorDatetime": "2012-05-04T04:00:00.000-04:00",
+      "category": "encounter",
+      "dataElementCodes": [
+        {
+          "codeSystem": "SNOMED-CT",
+          "code": "17436001"
+        },
+        {
+          "codeSystem": "CPT",
+          "code": "99241"
+        }
+      ],
+      "description": "Encounter, Performed: Outpatient Consultation",
+      "diagnoses": [
+
+      ],
+      "dischargeDisposition": null,
+      "facilityLocations": [
+
+      ],
+      "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+      "id": {
+        "namingSystem": null,
+        "qdmVersion": "5.3",
+        "value": "5b9fe2ddd7c8acf1740e5c68"
+      },
+      "lengthOfStay": {
+        "value": 136,
+        "unit": "days"
+      },
+      "negationRationale": null,
+      "principalDiagnosis": null,
+      "qdmStatus": "performed",
+      "qdmVersion": "5.3",
+      "relevantPeriod": {
+        "low": "2012-05-04T08:00:00.000+00:00",
+        "high": "2012-09-17T08:15:00.000+00:00",
+        "lowClosed": true,
+        "highClosed": true
+      },
+      "_type": "QDM::EncounterPerformed"
+    },
+    {
+      "activeDatetime": null,
+      "authorDatetime": "2012-05-04T04:00:00.000-04:00",
+      "category": "medication",
+      "dataElementCodes": [
+        {
+          "codeSystem": "RxNorm",
+          "code": "864978"
+        }
+      ],
+      "description": "Medication, Order: Opioid Medications",
+      "dosage": {
+        "value": 20,
+        "unit": "mg"
+      },
+      "frequency": {
+        "code": "229797004",
+        "codeSystem": "SNOMED-CT",
+        "descriptor": "Once daily (qualifier value)",
+        "codeSystemOid": null,
+        "version": null
+      },
+      "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+      "id": {
+        "namingSystem": null,
+        "qdmVersion": "5.3",
+        "value": "5b9fe2ddd7c8acf1740e5c67"
+      },
+      "method": null,
+      "negationRationale": null,
+      "qdmStatus": "order",
+      "qdmVersion": "5.3",
+      "reason": null,
+      "refills": null,
+      "relevantPeriod": {
+        "low": "2012-05-04T08:00:00.000+00:00",
+        "high": "2012-09-03T08:15:00.000+00:00",
+        "lowClosed": true,
+        "highClosed": true
+      },
+      "route": null,
+      "supply": null,
+      "_type": "QDM::MedicationOrder"
+    },
+    {
+      "birthDatetime": "1958-05-14T04:00:00.000-04:00",
+      "category": "patient_characteristic",
+      "dataElementCodes": [
+        {
+          "code": "21112-8",
+          "codeSystem": "LOINC",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null,
+          "_type": "QDM::Code"
+        }
+      ],
+      "description": null,
+      "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+      "id": {
+        "namingSystem": null,
+        "qdmVersion": "5.3",
+        "value": "5b9fe9a7d7c8ac2f8dcd003d"
+      },
+      "qdmStatus": "birthdate",
+      "qdmVersion": "5.3",
+      "_type": "QDM::PatientCharacteristicBirthdate"
+    },
+    {
+      "category": "patient_characteristic",
+      "dataElementCodes": [
+        {
+          "code": "2186-5",
+          "codeSystem": "CDC Race",
+          "descriptor": "Not Hispanic or Latino",
+          "codeSystemOid": "2.16.840.1.113883.6.238",
+          "version": null,
+          "_type": "QDM::Code"
+        }
+      ],
+      "description": null,
+      "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+      "id": {
+        "namingSystem": null,
+        "qdmVersion": "5.3",
+        "value": "5b9fe9a7d7c8ac2f8dcd003e"
+      },
+      "qdmStatus": "ethnicity",
+      "qdmVersion": "5.3",
+      "_type": "QDM::PatientCharacteristicEthnicity"
+    },
+    {
+      "category": "patient_characteristic",
+      "dataElementCodes": [
+        {
+          "code": "1002-5",
+          "codeSystem": "CDC Race",
+          "descriptor": "American Indian or Alaska Native",
+          "codeSystemOid": "2.16.840.1.113883.6.238",
+          "version": null,
+          "_type": "QDM::Code"
+        }
+      ],
+      "description": null,
+      "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+      "id": {
+        "namingSystem": null,
+        "qdmVersion": "5.3",
+        "value": "5b9fe9a7d7c8ac2f8dcd003f"
+      },
+      "qdmStatus": "race",
+      "qdmVersion": "5.3",
+      "_type": "QDM::PatientCharacteristicRace"
+    },
+    {
+      "category": "patient_characteristic",
+      "dataElementCodes": [
+        {
+          "code": "M",
+          "codeSystem": "AdministrativeGender",
+          "descriptor": "M",
+          "codeSystemOid": "2.16.840.1.113883.5.1",
+          "version": null,
+          "_type": "QDM::Code"
+        }
+      ],
+      "description": null,
+      "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+      "id": {
+        "namingSystem": null,
+        "qdmVersion": "5.3",
+        "value": "5b9fe9a7d7c8ac2f8dcd0040"
+      },
+      "qdmStatus": "gender",
+      "qdmVersion": "5.3",
+      "_type": "QDM::PatientCharacteristicSex"
+    }
+  ],
+  "extendedData": {
+    "type": null,
+    "measure_ids": [
+      "442EDEF2-7347-4080-988F-16C9D1998803",
+      null
+    ],
+    "source_data_criteria": [
+      {
+        "negation": false,
+        "definition": "medication",
+        "status": "ordered",
+        "title": "OpioidMedications",
+        "description": "Medication, Order: Opioid Medications",
+        "code_list_id": "2.16.840.1.113883.3.3157.1004.26",
+        "type": "medications",
+        "id": "OpioidMedications_MedicationOrder_9fa72c11_9e0b_481f_a2bb_5ac13e6ddd90_source",
+        "start_date": 1336118400000,
+        "end_date": 1346660100000,
+        "value": [
+
+        ],
+        "references": null,
+        "field_values": {
+          "FREQUENCY": {
+            "type": "CD",
+            "code_list_id": "drc-e6b5e12d54357f2eff60055d5aa19fbe4c458e863b9a4bb551a5ba5b3c8ca1c5",
+            "field_title": "Frequency",
+            "title": "Once daily (qualifier value)"
+          },
+          "DOSE": {
+            "type": "PQ",
+            "code_list_id": "",
+            "field_title": "Dosage",
+            "value": "20",
+            "unit": "mg"
+          }
+        },
+        "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+        "cms_id": "CMS460v0",
+        "criteria_id": "165e88ca914NW",
+        "codes": {
+          "RxNorm": [
+            "864978"
+          ]
+        },
+        "negation_code_list_id": "",
+        "coded_entry_id": "5b9fe2ddd7c8acf1740e5c67",
+        "code_source": "USER_DEFINED"
+      },
+      {
+        "negation": false,
+        "definition": "encounter",
+        "status": "performed",
+        "title": "OutpatientConsultation",
+        "description": "Encounter, Performed: Outpatient Consultation",
+        "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1008",
+        "type": "encounters",
+        "id": "OutpatientConsultation_EncounterPerformed_48dc260e_53e9_4934_91fc_958ce91f1008_source",
+        "start_date": 1336118400000,
+        "end_date": 1347869700000,
+        "value": [
+
+        ],
+        "references": null,
+        "field_values": {
+        },
+        "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+        "cms_id": "CMS460v0",
+        "criteria_id": "165e88c226dWY",
+        "codes": {
+          "SNOMED-CT": [
+            "17436001"
+          ],
+          "CPT": [
+            "99241"
+          ]
+        },
+        "negation_code_list_id": "",
+        "coded_entry_id": "5b9fe2ddd7c8acf1740e5c68",
+        "code_source": "DEFAULT"
+      },
+      {
+        "id": "MeasurePeriod",
+        "start_date": 0,
+        "end_date": 0,
+        "references": null
+      }
+    ],
+    "expected_values": [
+      {
+        "measure_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+        "population_index": 0,
+        "IPP": 1,
+        "DENOM": 1,
+        "DENEX": 0,
+        "NUMER": 0
+      }
+    ],
+    "notes": "methadone 40 mg oral tab does not exceed 90 MME (total daily dose is half a tablet (20 mg) which is 80 MME). Case does not meet NUMER criteria since MME is less than 90.",
+    "is_shared": null,
+    "origin_data": [
+
+    ],
+    "test_id": null,
+    "medical_record_number": "d152573c8e7a7718ec92f179ec1ffe97fa874d8e3a7a06877d188a6f67ad5e24",
+    "medical_record_assigner": "Bonnie",
+    "description": null,
+    "description_category": null,
+    "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199163600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+  },
+  "familyName": "NUMERFail",
+  "givenNames": [
+    "MethadoneLessThan90MME"
+  ],
+  "qdmVersion": "5.3"
+}

--- a/spec/fixtures/json/patients/CMS460v0/Opioid_Test.json
+++ b/spec/fixtures/json/patients/CMS460v0/Opioid_Test.json
@@ -61,7 +61,13 @@
         "value": 0.5,
         "unit": "mg"
       },
-      "frequency": null,
+      "frequency": {
+        "code": "229799001",
+        "codeSystem": "SNOMED-CT",
+        "descriptor": "Twice a day (qualifier value)",
+        "codeSystemOid": null,
+        "version": null
+      },
       "hqmfOid": "2.16.840.1.113883.3.560.1.17",
       "id": {
         "namingSystem": null,
@@ -73,7 +79,7 @@
       "qdmStatus": "order",
       "qdmVersion": "5.3",
       "reason": null,
-      "refills": null,
+      "refills": 2,
       "relevantPeriod": {
         "low": "2012-05-09T08:00:00.000+00:00",
         "high": "2012-12-28T08:15:00.000+00:00",
@@ -105,7 +111,7 @@
       "id": {
         "namingSystem": null,
         "qdmVersion": "5.3",
-        "value": "5b7eb84cef33a580dc8d8b9c"
+        "value": "5ba00d11d7c8acbd312c1500"
       },
       "qdmStatus": "birthdate",
       "qdmVersion": "5.3",
@@ -128,7 +134,7 @@
       "id": {
         "namingSystem": null,
         "qdmVersion": "5.3",
-        "value": "5b7eb84cef33a580dc8d8b9d"
+        "value": "5ba00d11d7c8acbd312c1501"
       },
       "qdmStatus": "ethnicity",
       "qdmVersion": "5.3",
@@ -151,7 +157,7 @@
       "id": {
         "namingSystem": null,
         "qdmVersion": "5.3",
-        "value": "5b7eb84cef33a580dc8d8b9e"
+        "value": "5ba00d11d7c8acbd312c1502"
       },
       "qdmStatus": "race",
       "qdmVersion": "5.3",
@@ -174,7 +180,7 @@
       "id": {
         "namingSystem": null,
         "qdmVersion": "5.3",
-        "value": "5b7eb84cef33a580dc8d8b9f"
+        "value": "5ba00d11d7c8acbd312c1503"
       },
       "qdmStatus": "gender",
       "qdmVersion": "5.3",

--- a/spec/helpers/results_helpers_spec.js
+++ b/spec/helpers/results_helpers_spec.js
@@ -111,10 +111,10 @@ describe('MeasureHelpers', () => {
         expect(result.get('statement_results').DayMonthTimings['Months Containing 29 Days'].pretty).toEqual('[1,\n2,\n3,\n4,\n5,\n6,\n7,\n8,\n9,\n10,\n11,\n12,\n13,\n14,\n15,\n16,' +
           '\n17,\n18,\n19,\n20,\n21,\n22,\n23,\n24,\n25,\n26,\n27,\n28,\n29]');
         expect(result.get('statement_results').PotentialOpioidOveruse['Prescription Days'].pretty).toContain('05/09/2012 12:00 AM');
-        expect(result.get('statement_results').PotentialOpioidOveruse['Prescription Days'].pretty).toContain('rxNormCode: CODE: RxNorm: 1053647');
+        expect(result.get('statement_results').PotentialOpioidOveruse['Prescription Days'].pretty).toContain('rxNormCode: CODE: RxNorm 1053647');
         expect(result.get('statement_results').PotentialOpioidOveruse['Prescriptions with MME'].pretty).toContain('conversionFactor: 0.13');
         expect(result.get('statement_results').PotentialOpioidOveruse['Prescriptions with MME'].pretty).toContain('effectivePeriod: INTERVAL: 05/09/2012 8:00 AM - 12/28/2012 8:15 AM');
-        expect(result.get('statement_results').PotentialOpioidOveruse['Prescriptions with MME'].pretty).toContain('rxNormCode: CODE: RxNorm: 1053647');
+        expect(result.get('statement_results').PotentialOpioidOveruse['Prescriptions with MME'].pretty).toContain('rxNormCode: CODE: RxNorm 1053647');
         expect(result.get('statement_results').OpioidData.DrugIngredients.pretty).toContain('drugName: "72 HR Fentanyl 0.075 MG/HR Transdermal System"');
       });
 

--- a/spec/models/calculator_spec.js
+++ b/spec/models/calculator_spec.js
@@ -550,9 +550,11 @@ describe('Calculator', () => {
       const measure = getJSONFixture('measures/CMS460v0/CMS460v0.json');
       const patients = [];
       patients.push(getJSONFixture('patients/CMS460v0/Opioid_Test.json'));
+      patients.push(getJSONFixture('patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json'));
       const options = { doPretty: true };
       const calculationResults = Calculator.calculate(measure, patients, valueSetsByOid, options);
       const result = Object.values(calculationResults[Object.keys(calculationResults)[0]])[0];
+      const conversionFactorResult = Object.values(calculationResults[Object.keys(calculationResults)[1]])[0];
       const indentedResult = '[{' +
       '\n  cmd: 233,' +
       '\n  meds: [Medication, Order: Opioid Medications' +
@@ -563,6 +565,7 @@ describe('Calculator', () => {
       '\n}]';
 
       expect(result.statement_results['PotentialOpioidOveruse']['Periods With and Without 7 Day Gap With Cumulative Med Duration 90 days or Greater']['pretty']).toEqual(indentedResult);
+      expect(conversionFactorResult.statement_results['PotentialOpioidOveruse']['Prescriptions with MME']['pretty']).toContain('conversionFactor: 4,');
     });
   });
 


### PR DESCRIPTION
This PR adds a patient fixture for the opioid measure that exhibits the issue causing excel diffs.  That issue was that medication order frequency was deleted in the converter.  The patient fixture uses the updated converter, but that change isn't in this repo.

Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1745
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Updated fixtures from new cqm-converter.

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
