### PR TITLE
Excel fixes

### DIFF
--- a/lib/helpers/calculator_helpers.js
+++ b/lib/helpers/calculator_helpers.js
@@ -71,6 +71,11 @@ module.exports = class CalculatorHelpers {
         });
       });
     }
+    // OBSERV comparisons depend on the values being sorted before comparing. 
+    // Sorting here at set time instead of in the comparison function.
+    if (populationResults.values) {
+      populationResults.values = populationResults.values.sort()
+    }
     return [populationResults, episodeResults];
   }
 
@@ -334,6 +339,13 @@ module.exports = class CalculatorHelpers {
     // Correct any inconsistencies. ex. In DENEX but also in NUMER using same function used for patients.
     Object.keys(episodeResults).forEach((episodeId) => {
       const episodeResult = episodeResults[episodeId];
+      // ensure that an empty 'values' array exists for continuous variable measures if there were no observations
+      if ([].indexOf.call(popCodesInPopulation, 'OBSERV') >= 0) {
+        if (!episodeResult.values) {
+          episodeResult.values = [];
+        }
+      }
+      // Correct any inconsistencies. ex. In DENEX but also in NUMER using same function used for patients.
       episodeResults[episodeId] = this.handlePopulationValues(episodeResult);
     });
 

--- a/lib/helpers/calculator_helpers.js
+++ b/lib/helpers/calculator_helpers.js
@@ -71,7 +71,6 @@ module.exports = class CalculatorHelpers {
         });
       });
     }
-
     return [populationResults, episodeResults];
   }
 

--- a/lib/helpers/calculator_helpers.js
+++ b/lib/helpers/calculator_helpers.js
@@ -71,11 +71,7 @@ module.exports = class CalculatorHelpers {
         });
       });
     }
-    // OBSERV comparisons depend on the values being sorted before comparing. 
-    // Sorting here at set time instead of in the comparison function.
-    if (populationResults.values) {
-      populationResults.values = populationResults.values.sort()
-    }
+
     return [populationResults, episodeResults];
   }
 

--- a/lib/helpers/results_helpers.js
+++ b/lib/helpers/results_helpers.js
@@ -656,6 +656,7 @@ module.exports = class ResultsHelpers {
 
     // If MSRPOPL is 0 then OBSERVs and MSRPOPLEX are not calculateed
     if (result.MSRPOPL != null && result.MSRPOPL === 0) {
+      // values is the OBSERVs
       if (resultShown.values != null) {
         resultShown.values = false;
       }
@@ -666,6 +667,7 @@ module.exports = class ResultsHelpers {
 
     // If MSRPOPLEX is greater than or equal to MSRPOPL then OBSERVs are not calculated
     if (result.MSRPOPLEX != null && result.MSRPOPLEX >= result.MSRPOPL) {
+      // values is the OBSERVs
       if (resultShown.values != null) {
         resultShown.values = false;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-execution",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.1",
   "description": "NPM module for calculating eCQMs (electronic clinical quality measures) written in CQL (clinical quality language).",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

Excel fixes for setting null values to [] for Observ values.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1749
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
