### PR TITLE
Update cqm-execution for 1.0.2 release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-execution",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NPM module for calculating eCQMs (electronic clinical quality measures) written in CQL (clinical quality language).",
   "main": "lib/index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "require-directory": "^2.1.1"
   },
   "dependencies": {
-    "cqm-models": "1.0.1",
+    "cqm-models": "1.0.2",
     "lodash": "^4.17.5",
     "moment": "^2.21.0",
     "mongoose": "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,18 +240,18 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cql-execution@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.1.tgz#79c5fe891202140f6f3d8371fb382765eba06a37"
+cql-execution@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.2.tgz#3599ef31a0196e8ee679a37e1eee1911d731360b"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-cqm-models@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-1.0.1.tgz#da2c27819bfa71bf71264ff7bcaae04158d7b48c"
+cqm-models@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-1.0.2.tgz#c337e13ad0608d970622adbe4bb5e9014560dfe5"
   dependencies:
-    cql-execution "1.3.1"
+    cql-execution "1.3.2"
     mongoose "^5.0.7"
 
 cross-spawn@^5.1.0:


### PR DESCRIPTION
Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:@mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
