### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
     - "node_modules"
 script:
   - yarn install
-  - npm run lint
-  - npm test
+  - yarn run lint
+  - yarn test
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
   directories:
     - "node_modules"
 script:
+  - yarn install
   - npm run lint
   - npm test
   - codecov


### PR DESCRIPTION
Istanbul was cached on travis, so migrating to travis.com made CI fail.  This PR fixes that by adding `yarn install`.  It also switches from npm to yarn in travis for consistency.

Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
