### PR TITLE
No coded uncertainty

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "require-directory": "^2.1.1"
   },
   "dependencies": {
-    "cqm-models": "https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty",
+    "cqm-models": "https://github.com/projecttacoma/cqm-models.git#bonnie-patch",
     "lodash": "^4.17.5",
     "moment": "^2.21.0",
     "mongoose": "^5.0.7"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "require-directory": "^2.1.1"
   },
   "dependencies": {
-    "cqm-models": "https://github.com/projecttacoma/cqm-models.git#bonnie-v3.1.1",
+    "cqm-models": "https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty",
     "lodash": "^4.17.5",
     "moment": "^2.21.0",
     "mongoose": "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,14 +242,14 @@ core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#19775fd74c97c5d054e69f5aa6a050d9bb4fe450"
+  resolved "https://github.com/cqframework/cql-execution.git#628b4565ce10ae373ecc5cbc6e073e49f5c32bf7"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
 "cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#a5aab0601eb0d7e5081bfe9bbc1852150452d2d0"
+  resolved "https://github.com/projecttacoma/cqm-models.git#4c8c8bdd5cafb560e378fbc4ca1d84030dd345ec"
   dependencies:
     cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
     mongoose "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,18 +240,18 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1":
+"cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#1f8976f2ce752925705887331de09caf46c86194"
+  resolved "https://github.com/cqframework/cql-execution.git#94dc5f68b1d9e13e6bff5637d0f96aa132759c13"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-"cqm-models@https://github.com/projecttacoma/cqm-models.git#bonnie-v3.1.1":
+"cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#0a7234da0dc3c1a9be1c0a48722452bc6713bcfa"
+  resolved "https://github.com/projecttacoma/cqm-models.git#ca83738c74d85c5e8e4af4a9d27077cec42aec8b"
   dependencies:
-    cql-execution "https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1"
+    cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
     mongoose "^5.0.7"
 
 cross-spawn@^5.1.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,7 +249,7 @@ core-util-is@~1.0.0:
 
 "cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#7b7b21b2173beb993df030b071dd8b22d0bb9497"
+  resolved "https://github.com/projecttacoma/cqm-models.git#a5aab0601eb0d7e5081bfe9bbc1852150452d2d0"
   dependencies:
     cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
     mongoose "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,18 +240,18 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
+"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-patch":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#628b4565ce10ae373ecc5cbc6e073e49f5c32bf7"
+  resolved "https://github.com/cqframework/cql-execution.git#cc3cfe97e06d9804106149116e2bd599ad932611"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-"cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
+"cqm-models@https://github.com/projecttacoma/cqm-models.git#bonnie-patch":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#4c8c8bdd5cafb560e378fbc4ca1d84030dd345ec"
+  resolved "https://github.com/projecttacoma/cqm-models.git#ed2ce3c13b5319ee2c4c25b0d4a1545bf935105c"
   dependencies:
-    cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
+    cql-execution "https://github.com/cqframework/cql-execution.git#bonnie-patch"
     mongoose "^5.0.7"
 
 cross-spawn@^5.1.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,7 +249,7 @@ core-util-is@~1.0.0:
 
 "cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#ca83738c74d85c5e8e4af4a9d27077cec42aec8b"
+  resolved "https://github.com/projecttacoma/cqm-models.git#0aeb882a068ce6cb739e1d73fa86503505bb528e"
   dependencies:
     cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
     mongoose "^5.0.7"
@@ -271,6 +271,7 @@ debug@2.6.9, debug@^2.6.8, debug@^2.6.9:
 debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -1185,6 +1186,7 @@ rx-lite@*, rx-lite@^4.0.8:
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,14 +242,14 @@ core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#94dc5f68b1d9e13e6bff5637d0f96aa132759c13"
+  resolved "https://github.com/cqframework/cql-execution.git#19775fd74c97c5d054e69f5aa6a050d9bb4fe450"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
 "cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#0aeb882a068ce6cb739e1d73fa86503505bb528e"
+  resolved "https://github.com/projecttacoma/cqm-models.git#7b7b21b2173beb993df030b071dd8b22d0bb9497"
   dependencies:
     cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
     mongoose "^5.0.7"


### PR DESCRIPTION
Hash updates for bonnie patch release
Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1938
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
