### PR TITLE
Fix msrpoplex

### DIFF
--- a/dist/browser.js
+++ b/dist/browser.js
@@ -121,6 +121,9 @@ module.exports = class CalculatorHelpers {
       if ('NUMEX' in populationResults) {
         populationResultsHandled.NUMEX = 0;
       }
+      if ('MSRPOPLEX' in populationResults) {
+        populationResultsHandled.MSRPOPLEX = 0;
+      }
       if ('values' in populationResults) {
         populationResultsHandled.values = [];
       }

--- a/lib/helpers/calculator_helpers.js
+++ b/lib/helpers/calculator_helpers.js
@@ -115,6 +115,9 @@ module.exports = class CalculatorHelpers {
       if ('NUMEX' in populationResults) {
         populationResultsHandled.NUMEX = 0;
       }
+      if ('MSRPOPLEX' in populationResults) {
+        populationResultsHandled.MSRPOPLEX = 0;
+      }
       if ('values' in populationResults) {
         populationResultsHandled.values = [];
       }

--- a/spec/helpers/calculator_helpers_spec.js
+++ b/spec/helpers/calculator_helpers_spec.js
@@ -1,0 +1,90 @@
+const CalculatorHelpers = require('../../lib/helpers/calculator_helpers.js');
+
+describe('CalculatorHelpers', () => {
+  describe('handlePopulationValues', () => {
+    it('NUMER population not modified by inclusion in NUMEX', () => {
+      initial_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 1, NUMEX: 1};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(initial_results);
+    });
+
+    it('NUMEX membership removed when not a member of NUMER', () => {
+      initial_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 0, NUMEX: 1};
+      expected_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('NUMEX membership removed when not a member of DENOM', () => {
+      initial_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 1};
+      expected_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('DENOM population not modified by inclusion in DENEX', () => {
+      initial_results = {IPP: 1, DENOM: 1, DENEX: 1, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(initial_results);
+    });
+
+    it('DENEX membership removed when not a member of DENOM', () => {
+      initial_results = {IPP: 1, DENOM: 0, DENEX: 1, NUMER: 0, NUMEX: 0};
+      expected_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('MSRPOPLEX should be 0 if MSRPOPL not satisfied', () => {
+      initial_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 1};
+      expected_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+
+      initial_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 0};
+      expected_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('MSRPOPLEX should be unchanged if MSRPOPL satisfied', () => {
+      initial_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1};
+      expected_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+
+      initial_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0};
+      expected_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('NUMER and NUMEX membership removed there are same counts in DENEX as DENOM', () => {
+      initial_results = {IPP: 2, DENOM: 2, DENEX: 2, NUMER: 2, NUMEX: 1};
+      expected_results = {IPP: 2, DENOM: 2, DENEX: 2, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('NUMER and NUMEX membership removed there are more counts in DENEX than DENOM', () => {
+      initial_results = {IPP: 3, DENOM: 2, DENEX: 3, NUMER: 2, NUMEX: 1};
+      expected_results = {IPP: 3, DENOM: 2, DENEX: 3, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('NUMER and NUMEX membership kept if there are less counts in DENEX as DENOM', () => {
+      initial_results = {IPP: 2, DENOM: 2, DENEX: 1, NUMER: 1, NUMEX: 0};
+      expected_results = {IPP: 2, DENOM: 2, DENEX: 1, NUMER: 1, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+
+    it('DENEXCEP and NUMER membership removed if a member of DENEX', () => {
+      initial_results = {IPP: 1, DENOM: 1, DENEX: 1, DENEXCEP: 1, NUMER: 1, NUMEX: 0};
+      expected_results = {IPP: 1, DENOM: 1, DENEX: 1, DENEXCEP: 0, NUMER: 0, NUMEX: 0};
+      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
+      expect(processed_results).toEqual(expected_results);
+    });
+  });
+});

--- a/spec/helpers/calculator_helpers_spec.js
+++ b/spec/helpers/calculator_helpers_spec.js
@@ -3,88 +3,218 @@ const CalculatorHelpers = require('../../lib/helpers/calculator_helpers.js');
 describe('CalculatorHelpers', () => {
   describe('handlePopulationValues', () => {
     it('NUMER population not modified by inclusion in NUMEX', () => {
-      initial_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 1, NUMEX: 1};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(initial_results);
+      const initialResults = {
+        IPP: 1,
+        DENOM: 1,
+        DENEX: 0,
+        NUMER: 1,
+        NUMEX: 1,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(initialResults);
     });
 
     it('NUMEX membership removed when not a member of NUMER', () => {
-      initial_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 0, NUMEX: 1};
-      expected_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 1,
+        DENOM: 1,
+        DENEX: 0,
+        NUMER: 0,
+        NUMEX: 1,
+      };
+      const expectedResults = {
+        IPP: 1,
+        DENOM: 1,
+        DENEX: 0,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('NUMEX membership removed when not a member of DENOM', () => {
-      initial_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 1};
-      expected_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 1,
+        DENOM: 0,
+        DENEX: 0,
+        NUMER: 0,
+        NUMEX: 1,
+      };
+      const expectedResults = {
+        IPP: 1,
+        DENOM: 0,
+        DENEX: 0,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('DENOM population not modified by inclusion in DENEX', () => {
-      initial_results = {IPP: 1, DENOM: 1, DENEX: 1, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(initial_results);
+      const initialResults = {
+        IPP: 1,
+        DENOM: 1,
+        DENEX: 1,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(initialResults);
     });
 
     it('DENEX membership removed when not a member of DENOM', () => {
-      initial_results = {IPP: 1, DENOM: 0, DENEX: 1, NUMER: 0, NUMEX: 0};
-      expected_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 1,
+        DENOM: 0,
+        DENEX: 1,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const expectedResults = {
+        IPP: 1,
+        DENOM: 0,
+        DENEX: 0,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('MSRPOPLEX should be 0 if MSRPOPL not satisfied', () => {
-      initial_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 1};
-      expected_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      let initialResults = {
+        IPP: 1,
+        MSRPOPL: 0,
+        MSRPOPLEX: 1,
+      };
+      let expectedResults = {
+        IPP: 1,
+        MSRPOPL: 0,
+        MSRPOPLEX: 0,
+      };
+      let processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
 
-      initial_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 0};
-      expected_results = {IPP: 1, MSRPOPL: 0, MSRPOPLEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      initialResults = {
+        IPP: 1,
+        MSRPOPL: 0,
+        MSRPOPLEX: 0,
+      };
+      expectedResults = {
+        IPP: 1,
+        MSRPOPL: 0,
+        MSRPOPLEX: 0,
+      };
+      processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('MSRPOPLEX should be unchanged if MSRPOPL satisfied', () => {
-      initial_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1};
-      expected_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      let initialResults = {
+        IPP: 1,
+        MSRPOPL: 1,
+        MSRPOPLEX: 1,
+      };
+      let expectedResults = {
+        IPP: 1,
+        MSRPOPL: 1,
+        MSRPOPLEX: 1,
+      };
+      let processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
 
-      initial_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0};
-      expected_results = {IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      initialResults = {
+        IPP: 1,
+        MSRPOPL: 1,
+        MSRPOPLEX: 0,
+      };
+      expectedResults = {
+        IPP: 1,
+        MSRPOPL: 1,
+        MSRPOPLEX: 0,
+      };
+      processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('NUMER and NUMEX membership removed there are same counts in DENEX as DENOM', () => {
-      initial_results = {IPP: 2, DENOM: 2, DENEX: 2, NUMER: 2, NUMEX: 1};
-      expected_results = {IPP: 2, DENOM: 2, DENEX: 2, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 2,
+        DENOM: 2,
+        DENEX: 2,
+        NUMER: 2,
+        NUMEX: 1,
+      };
+      const expectedResults = {
+        IPP: 2,
+        DENOM: 2,
+        DENEX: 2,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('NUMER and NUMEX membership removed there are more counts in DENEX than DENOM', () => {
-      initial_results = {IPP: 3, DENOM: 2, DENEX: 3, NUMER: 2, NUMEX: 1};
-      expected_results = {IPP: 3, DENOM: 2, DENEX: 3, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 3,
+        DENOM: 2,
+        DENEX: 3,
+        NUMER: 2,
+        NUMEX: 1,
+      };
+      const expectedResults = {
+        IPP: 3,
+        DENOM: 2,
+        DENEX: 3,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('NUMER and NUMEX membership kept if there are less counts in DENEX as DENOM', () => {
-      initial_results = {IPP: 2, DENOM: 2, DENEX: 1, NUMER: 1, NUMEX: 0};
-      expected_results = {IPP: 2, DENOM: 2, DENEX: 1, NUMER: 1, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 2,
+        DENOM: 2,
+        DENEX: 1,
+        NUMER: 1,
+        NUMEX: 0,
+      };
+      const expectedResults = {
+        IPP: 2,
+        DENOM: 2,
+        DENEX: 1,
+        NUMER: 1,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
 
     it('DENEXCEP and NUMER membership removed if a member of DENEX', () => {
-      initial_results = {IPP: 1, DENOM: 1, DENEX: 1, DENEXCEP: 1, NUMER: 1, NUMEX: 0};
-      expected_results = {IPP: 1, DENOM: 1, DENEX: 1, DENEXCEP: 0, NUMER: 0, NUMEX: 0};
-      processed_results = CalculatorHelpers.handlePopulationValues(initial_results);
-      expect(processed_results).toEqual(expected_results);
+      const initialResults = {
+        IPP: 1,
+        DENOM: 1,
+        DENEX: 1,
+        DENEXCEP: 1,
+        NUMER: 1,
+        NUMEX: 0,
+      };
+      const expectedResults = {
+        IPP: 1,
+        DENOM: 1,
+        DENEX: 1,
+        DENEXCEP: 0,
+        NUMER: 0,
+        NUMEX: 0,
+      };
+      const processedResults = CalculatorHelpers.handlePopulationValues(initialResults);
+      expect(processedResults).toEqual(expectedResults);
     });
   });
 });


### PR DESCRIPTION
There was a missing condition in handlePopulationValues that was added to Bonnie after that function was ported to cqm-execution.  This PR adds it and ports the tests for that function from bonnie to this repository.

See https://github.com/projecttacoma/bonnie/pull/1235 for the source of the tests ported over.

Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1990
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @zlister 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
