### PR TITLE
MAT-3008 Keep old logic for measure observations in composite measures

### DIFF
--- a/dist/browser.js
+++ b/dist/browser.js
@@ -1683,7 +1683,9 @@ module.exports = class Calculator {
       observations.forEach((obs) => {
         const funcName = obs.observation_function.statement_name;
         const param = obs.observation_parameter.statement_name;
-        generatedELMJSON = (measure.calculation_method === 'PATIENT') ? CalculatorHelpers.generatePatientELMJSONFunction(funcName) : CalculatorHelpers.generateEpisodeELMJSONFunction(funcName, param);
+        generatedELMJSON = (measure.calculation_method === 'PATIENT' && !measure.composite)
+          ? CalculatorHelpers.generatePatientELMJSONFunction(funcName)
+          : CalculatorHelpers.generateEpisodeELMJSONFunction(funcName, param);
         // Save the name of the generated define statement, so we can check
         // its result later in the CQL calculation process. These added
         // define statements are called 'obs_func_' followed by the

--- a/lib/models/calculator.js
+++ b/lib/models/calculator.js
@@ -92,9 +92,9 @@ module.exports = class Calculator {
       observations.forEach((obs) => {
         const funcName = obs.observation_function.statement_name;
         const param = obs.observation_parameter.statement_name;
-        generatedELMJSON = (measure.calculation_method === 'PATIENT' && !measure.composite) ?
-          CalculatorHelpers.generatePatientELMJSONFunction(funcName) :
-          CalculatorHelpers.generateEpisodeELMJSONFunction(funcName, param);
+        generatedELMJSON = (measure.calculation_method === 'PATIENT' && !measure.composite)
+          ? CalculatorHelpers.generatePatientELMJSONFunction(funcName)
+          : CalculatorHelpers.generateEpisodeELMJSONFunction(funcName, param);
         // Save the name of the generated define statement, so we can check
         // its result later in the CQL calculation process. These added
         // define statements are called 'obs_func_' followed by the

--- a/lib/models/calculator.js
+++ b/lib/models/calculator.js
@@ -92,7 +92,9 @@ module.exports = class Calculator {
       observations.forEach((obs) => {
         const funcName = obs.observation_function.statement_name;
         const param = obs.observation_parameter.statement_name;
-        generatedELMJSON = (measure.calculation_method === 'PATIENT') ? CalculatorHelpers.generatePatientELMJSONFunction(funcName) : CalculatorHelpers.generateEpisodeELMJSONFunction(funcName, param);
+        generatedELMJSON = (measure.calculation_method === 'PATIENT' && !measure.composite) ?
+          CalculatorHelpers.generatePatientELMJSONFunction(funcName) :
+          CalculatorHelpers.generateEpisodeELMJSONFunction(funcName, param);
         // Save the name of the generated define statement, so we can check
         // its result later in the CQL calculation process. These added
         // define statements are called 'obs_func_' followed by the


### PR DESCRIPTION
Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
