### PR TITLE
MAT-3008 obsResult can be an array

### DIFF
--- a/dist/browser.js
+++ b/dist/browser.js
@@ -195,8 +195,21 @@ module.exports = class CalculatorHelpers {
           patientResults != null
             ? patientResults[obDef]
             : undefined;
-
-        populationResults.observation_values.push(obsResults);
+        if (Array.isArray(obsResults)) {
+          obsResults.forEach((obsResult) => {
+            // Add the single result value to the values array on the results of
+            // this calculation (allowing for more than one possible observation).
+            if (obsResult != null ? Object.prototype.hasOwnProperty.call(obsResult, 'value') : undefined) {
+              // If result is a Cql.Quantity type, add its value
+              populationResults.observation_values.push(obsResult.observation.value);
+            } else {
+              // In all other cases, add result
+              populationResults.observation_values.push(obsResult.observation);
+            }
+          });
+        } else {
+          populationResults.observation_values.push(obsResults);
+        }
       });
     }
 

--- a/lib/helpers/calculator_helpers.js
+++ b/lib/helpers/calculator_helpers.js
@@ -189,8 +189,21 @@ module.exports = class CalculatorHelpers {
           patientResults != null
             ? patientResults[obDef]
             : undefined;
-
-        populationResults.observation_values.push(obsResults);
+        if (Array.isArray(obsResults)) {
+          obsResults.forEach((obsResult) => {
+            // Add the single result value to the values array on the results of
+            // this calculation (allowing for more than one possible observation).
+            if (obsResult != null ? Object.prototype.hasOwnProperty.call(obsResult, 'value') : undefined) {
+              // If result is a Cql.Quantity type, add its value
+              populationResults.observation_values.push(obsResult.observation.value);
+            } else {
+              // In all other cases, add result
+              populationResults.observation_values.push(obsResult.observation);
+            }
+          });
+        } else {
+          populationResults.observation_values.push(obsResults);
+        }
       });
     }
 


### PR DESCRIPTION
Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
