### PR TITLE
Use cqm-models v4.0.0(QDM5.6 models)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "require-directory": "^2.1.1"
   },
   "dependencies": {
-    "cqm-models": "https://github.com/projecttacoma/cqm-models.git#c1b6383b0e91bdb968aa16ed390065e3ea47c72c",
+    "cqm-models": "~4.0.0",
     "lodash": "^4.17.19",
     "moment": "^2.21.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,9 +560,10 @@ cql-execution@~2.2.0:
     "@lhncbc/ucum-lhc" "^4.1.3"
     luxon "^1.25.0"
 
-"cqm-models@https://github.com/projecttacoma/cqm-models.git#c1b6383b0e91bdb968aa16ed390065e3ea47c72c":
+cqm-models@~4.0.0:
   version "4.0.0"
-  resolved "https://github.com/projecttacoma/cqm-models.git#c1b6383b0e91bdb968aa16ed390065e3ea47c72c"
+  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-4.0.0.tgz#bb3622e7ac9540288d3385d7a7e096f32ee835c1"
+  integrity sha512-/aNGPEMv6SmigzCrn5YzAsGAF1oUE6g6VYVKEe5znMyCFxyCtqCb8eqQtZ2yF8P9S6/eDx8/91eo44ishu670g==
   dependencies:
     cql-execution "~2.2.0"
     mongoose "^5.11.10"


### PR DESCRIPTION
Use cqm-models v4.0.0(QDM5.6 models)
replaced direct cqm-models git branch usage with npm package
readme is already uptodate

Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: MAT-2837 Release cqm-execution NPM Package
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
