### PR TITLE
MAT-7668: Ignore localIds not related to coverage calculation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/dist/browser.js
+++ b/dist/browser.js
@@ -674,6 +674,9 @@ module.exports = class MeasureHelpers {
     emptyResultClauses,
     parentNode,
   ) {
+    // Nearly all ELM nodes now have a localId. We can no longer rely on the presence or lack of a localId to determine
+    // whether a node's localId should be collected.
+
     // Stop recursing if this node happens to be any TypeSpecifier. We do not want to collect localIds for these clauses
     // as they are not executed and will negatively affect clause coverage if captured here. ChoiceTypeSpecifiers do not
     // identify their type and instead put [] at the `type` attribute which is a deprecated field.
@@ -684,6 +687,9 @@ module.exports = class MeasureHelpers {
     ) {
       return localIds;
     }
+    // Stop recursing if this node represents the Patient obj since it is not part of coverage consideration. 
+    if (statement?.name === "Patient") return localIds;
+
     // looking at the key and value of everything on this object or array
     for (const k in statement) {
       let alId;
@@ -872,7 +878,7 @@ module.exports = class MeasureHelpers {
       } else if (k === 'localId') {
         localIds[v] = { localId: v };
         // if the value is an array or object, recurse
-      } else if (Array.isArray(v) || typeof v === 'object') {
+      } else if (Array.isArray(v) || (typeof v === 'object' && k !== "codes")) {
         this.findAllLocalIdsInStatement(
           v,
           libraryName,

--- a/dist/browser.js-e
+++ b/dist/browser.js-e
@@ -123,12 +123,12 @@ module.exports = class CalculatorHelpers {
         if ('observation_values' in populationResults) {
           // DENOM observation will be the first of 2 observations
           populationResultsHandled.observation_values[1] = populationResultsHandled.observation_values[0];
-          populationResultsHandled.observation_values[0] = 0;
+          populationResultsHandled.observation_values[0] = null;
         }
       }
       if (populationResults.DENEX != null && !this.isValueZero('DENEX', populationResults) && populationResults.DENEX >= populationResults.DENOM) {
         if ('observation_values' in populationResults) {
-          populationResultsHandled.observation_values[0] = 0;
+          populationResultsHandled.observation_values[0] = null;
         }
       }
       if (this.isValueZero('NUMER', populationResults)) {
@@ -137,13 +137,13 @@ module.exports = class CalculatorHelpers {
         }
         if ('observation_values' in populationResults) {
           // NUMER observation will be the second of 2 observations
-          populationResultsHandled.observation_values[1] = 0;
+          populationResultsHandled.observation_values[1] = null;
         }
       }
       if (populationResults.NUMER != null && !this.isValueZero('NUMEX', populationResults) && populationResults.NUMEX >= populationResults.NUMER) {
         if ('observation_values' in populationResults) {
           // NUMER observation will be the second of 2 observations
-          populationResultsHandled.observation_values[1] = 0;
+          populationResultsHandled.observation_values[1] = null;
         }
       }
       return populationResultsHandled;
@@ -544,7 +544,7 @@ module.exports = class CalculatorHelpers {
   }
 };
 
-},{"cqm-models":192,"moment":218}],3:[function(require,module,exports){
+},{"cqm-models":192,"moment":226}],3:[function(require,module,exports){
 const _ = require('lodash');
 
 /**
@@ -674,6 +674,9 @@ module.exports = class MeasureHelpers {
     emptyResultClauses,
     parentNode,
   ) {
+    // Nearly all ELM nodes now have a localId. We can no longer rely on the presence or lack of a localId to determine
+    // whether a node's localId should be collected.
+
     // Stop recursing if this node happens to be any TypeSpecifier. We do not want to collect localIds for these clauses
     // as they are not executed and will negatively affect clause coverage if captured here. ChoiceTypeSpecifiers do not
     // identify their type and instead put [] at the `type` attribute which is a deprecated field.
@@ -684,6 +687,9 @@ module.exports = class MeasureHelpers {
     ) {
       return localIds;
     }
+    // Stop recursing if this node represents the Patient obj since it is not part of coverage consideration. 
+    if (statement?.name === "Patient") return localIds;
+
     // looking at the key and value of everything on this object or array
     for (const k in statement) {
       let alId;
@@ -872,7 +878,7 @@ module.exports = class MeasureHelpers {
       } else if (k === 'localId') {
         localIds[v] = { localId: v };
         // if the value is an array or object, recurse
-      } else if (Array.isArray(v) || typeof v === 'object') {
+      } else if (Array.isArray(v) || (typeof v === 'object' && k !== "codes")) {
         this.findAllLocalIdsInStatement(
           v,
           libraryName,
@@ -1086,7 +1092,7 @@ module.exports = class MeasureHelpers {
   }
 };
 
-},{"lodash":216}],4:[function(require,module,exports){
+},{"lodash":224}],4:[function(require,module,exports){
 /* eslint-disable camelcase */
 const _ = require('lodash');
 const CqmModels = require('cqm-models');
@@ -1835,7 +1841,7 @@ module.exports = class ResultsHelpers {
   }
 };
 
-},{"./measure_helpers":3,"cqm-models":192,"lodash":216,"moment":218}],5:[function(require,module,exports){
+},{"./measure_helpers":3,"cqm-models":192,"lodash":224,"moment":226}],5:[function(require,module,exports){
 module.exports.CalculatorHelpers = require('./helpers/calculator_helpers');
 module.exports.MeasureHelpers = require('./helpers/measure_helpers');
 module.exports.ResultsHelpers = require('./helpers/results_helpers');
@@ -2074,7 +2080,7 @@ module.exports = class Calculator {
   }
 };
 
-},{"../helpers/calculator_helpers":2,"../helpers/results_helpers":4,"./patient_source":7,"cqm-models":192,"lodash":216}],7:[function(require,module,exports){
+},{"../helpers/calculator_helpers":2,"../helpers/results_helpers":4,"./patient_source":7,"cqm-models":192,"lodash":224}],7:[function(require,module,exports){
 // This is a wrapper class for an array of QDM Patients
 // This class adds functions used by the execution engine to
 // traverse an array of QDM Patients
@@ -2579,7 +2585,7 @@ class Dimension {
 exports.Dimension = Dimension;
 
 
-},{"./config.js":9,"is-integer":213}],11:[function(require,module,exports){
+},{"./config.js":9,"is-integer":221}],11:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -5002,7 +5008,7 @@ class Unit {
 exports.Unit = Unit;
 
 
-},{"./config.js":9,"./dimension.js":10,"./ucumFunctions.js":14,"./ucumInternalUtils.js":15,"./unitTables.js":21,"is-integer":213}],20:[function(require,module,exports){
+},{"./config.js":9,"./dimension.js":10,"./ucumFunctions.js":14,"./ucumInternalUtils.js":15,"./unitTables.js":21,"is-integer":221}],20:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -7276,7 +7282,7 @@ exports.UnitTables = UnitTables;
 (function (global){(function (){
 'use strict';
 
-var objectAssign = require('object-assign');
+var objectAssign = require('object.assign/polyfill')();
 
 // compare and isBuffer taken from https://github.com/feross/buffer/blob/680e9e5e488f22aac27599a57dc844a6315928dd/index.js
 // original notice:
@@ -7782,7 +7788,7 @@ var objectKeys = Object.keys || function (obj) {
 };
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"object-assign":361,"util/":25}],23:[function(require,module,exports){
+},{"object.assign/polyfill":373,"util/":25}],23:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -8404,30 +8410,20 @@ function hasOwnProperty(obj, prop) {
 }
 
 }).call(this)}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./support/isBuffer":24,"_process":362,"inherits":23}],26:[function(require,module,exports){
+},{"./support/isBuffer":24,"_process":375,"inherits":23}],26:[function(require,module,exports){
 (function (global){(function (){
 'use strict';
 
-var possibleNames = [
-	'BigInt64Array',
-	'BigUint64Array',
-	'Float32Array',
-	'Float64Array',
-	'Int16Array',
-	'Int32Array',
-	'Int8Array',
-	'Uint16Array',
-	'Uint32Array',
-	'Uint8Array',
-	'Uint8ClampedArray'
-];
+var possibleNames = require('possible-typed-array-names');
 
 var g = typeof globalThis === 'undefined' ? global : globalThis;
 
+/** @type {import('.')} */
 module.exports = function availableTypedArrays() {
-	var out = [];
+	var /** @type {ReturnType<typeof availableTypedArrays>} */ out = [];
 	for (var i = 0; i < possibleNames.length; i++) {
 		if (typeof g[possibleNames[i]] === 'function') {
+			// @ts-expect-error
 			out[out.length] = possibleNames[i];
 		}
 	}
@@ -8435,7 +8431,7 @@ module.exports = function availableTypedArrays() {
 };
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],27:[function(require,module,exports){
+},{"possible-typed-array-names":374}],27:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -14213,7 +14209,7 @@ module.exports = ret;
 },{"./es5":13}]},{},[4])(4)
 });                    ;if (typeof window !== 'undefined' && window !== null) {                               window.P = window.Promise;                                                     } else if (typeof self !== 'undefined' && self !== null) {                             self.P = self.Promise;                                                         }
 }).call(this)}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("timers").setImmediate)
-},{"_process":362,"timers":367}],29:[function(require,module,exports){
+},{"_process":375,"timers":380}],29:[function(require,module,exports){
 (function (global){(function (){
 /**
  * Module dependencies.
@@ -17494,7 +17490,7 @@ module.exports.ObjectID = ObjectID;
 module.exports.ObjectId = ObjectID;
 
 }).call(this)}).call(this,require('_process'),require("buffer").Buffer)
-},{"./parser/utils":45,"_process":362,"buffer":49,"util":370}],42:[function(require,module,exports){
+},{"./parser/utils":45,"_process":375,"buffer":49,"util":383}],42:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -19735,7 +19731,7 @@ BSON.JS_INT_MIN = -0x20000000000000; // Any integer down to -2^53 can be precise
 module.exports = serializeInto;
 
 }).call(this)}).call(this,{"isBuffer":require("../../../../is-buffer/index.js")})
-},{"../../../../is-buffer/index.js":209,"../binary":29,"../float_parser":35,"../long":37,"../map":38,"./utils":45}],45:[function(require,module,exports){
+},{"../../../../is-buffer/index.js":217,"../binary":29,"../float_parser":35,"../long":37,"../map":38,"./utils":45}],45:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -19856,7 +19852,7 @@ module.exports = Symbol;
 module.exports.Symbol = Symbol;
 
 }).call(this)}).call(this,require("buffer").Buffer)
-},{"buffer":49,"util":370}],48:[function(require,module,exports){
+},{"buffer":49,"util":383}],48:[function(require,module,exports){
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22493,7 +22489,7 @@ function numberIsNaN (obj) {
 }
 
 }).call(this)}).call(this,require("buffer").Buffer)
-},{"base64-js":27,"buffer":49,"ieee754":206}],50:[function(require,module,exports){
+},{"base64-js":27,"buffer":49,"ieee754":214}],50:[function(require,module,exports){
 'use strict';
 
 var GetIntrinsic = require('get-intrinsic');
@@ -22510,29 +22506,20 @@ module.exports = function callBoundIntrinsic(name, allowMissing) {
 	return intrinsic;
 };
 
-},{"./":51,"get-intrinsic":198}],51:[function(require,module,exports){
+},{"./":51,"get-intrinsic":206}],51:[function(require,module,exports){
 'use strict';
 
 var bind = require('function-bind');
 var GetIntrinsic = require('get-intrinsic');
 var setFunctionLength = require('set-function-length');
 
-var $TypeError = GetIntrinsic('%TypeError%');
+var $TypeError = require('es-errors/type');
 var $apply = GetIntrinsic('%Function.prototype.apply%');
 var $call = GetIntrinsic('%Function.prototype.call%');
 var $reflectApply = GetIntrinsic('%Reflect.apply%', true) || bind.call($call, $apply);
 
-var $defineProperty = GetIntrinsic('%Object.defineProperty%', true);
+var $defineProperty = require('es-define-property');
 var $max = GetIntrinsic('%Math.max%');
-
-if ($defineProperty) {
-	try {
-		$defineProperty({}, 'a', { value: 1 });
-	} catch (e) {
-		// IE 8 has a broken defineProperty
-		$defineProperty = null;
-	}
-}
 
 module.exports = function callBind(originalFunction) {
 	if (typeof originalFunction !== 'function') {
@@ -22556,7 +22543,7 @@ if ($defineProperty) {
 	module.exports.apply = applyBind;
 }
 
-},{"function-bind":197,"get-intrinsic":198,"set-function-length":365}],52:[function(require,module,exports){
+},{"es-define-property":194,"es-errors/type":200,"function-bind":205,"get-intrinsic":206,"set-function-length":378}],52:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CodeService = void 0;
@@ -24269,7 +24256,7 @@ function isPrecisionUnspecifiedOrGreaterThanDay(precision) {
     return precision == null || /^h|mi|s/.test(precision);
 }
 
-},{"../util/util":105,"./uncertainty":63,"luxon":217}],58:[function(require,module,exports){
+},{"../util/util":105,"./uncertainty":63,"luxon":225}],58:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Exception = void 0;
@@ -33282,7 +33269,7 @@ class AdverseEvent extends mongoose.Document {
 module.exports.AdverseEvent = AdverseEvent;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],107:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],107:[function(require,module,exports){
 module.exports.Identifier = require('./attributes/Identifier.js').Identifier;
 module.exports.IdentifierSchema = require('./attributes/Identifier.js').IdentifierSchema;
 module.exports.Entity = require('./attributes/Entity.js').Entity;
@@ -33460,7 +33447,7 @@ class AllergyIntolerance extends mongoose.Document {
 module.exports.AllergyIntolerance = AllergyIntolerance;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],109:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],109:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33507,7 +33494,7 @@ class AssessmentOrder extends mongoose.Document {
 module.exports.AssessmentOrder = AssessmentOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],110:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],110:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33561,7 +33548,7 @@ class AssessmentPerformed extends mongoose.Document {
 module.exports.AssessmentPerformed = AssessmentPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],111:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],111:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33608,7 +33595,7 @@ class AssessmentRecommended extends mongoose.Document {
 module.exports.AssessmentRecommended = AssessmentRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],112:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],112:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33655,7 +33642,7 @@ class CareGoal extends mongoose.Document {
 module.exports.CareGoal = CareGoal;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],113:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],113:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33707,7 +33694,7 @@ class CommunicationPerformed extends mongoose.Document {
 module.exports.CommunicationPerformed = CommunicationPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],114:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],114:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33754,7 +33741,7 @@ class DeviceOrder extends mongoose.Document {
 module.exports.DeviceOrder = DeviceOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],115:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],115:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33801,7 +33788,7 @@ class DeviceRecommended extends mongoose.Document {
 module.exports.DeviceRecommended = DeviceRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],116:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],116:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33849,7 +33836,7 @@ class Diagnosis extends mongoose.Document {
 module.exports.Diagnosis = Diagnosis;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],117:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],117:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33896,7 +33883,7 @@ class DiagnosticStudyOrder extends mongoose.Document {
 module.exports.DiagnosticStudyOrder = DiagnosticStudyOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],118:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],118:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -33953,7 +33940,7 @@ class DiagnosticStudyPerformed extends mongoose.Document {
 module.exports.DiagnosticStudyPerformed = DiagnosticStudyPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],119:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],119:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34000,7 +33987,7 @@ class DiagnosticStudyRecommended extends mongoose.Document {
 module.exports.DiagnosticStudyRecommended = DiagnosticStudyRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],120:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],120:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34049,7 +34036,7 @@ class EncounterOrder extends mongoose.Document {
 module.exports.EncounterOrder = EncounterOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],121:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],121:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34106,7 +34093,7 @@ class EncounterPerformed extends mongoose.Document {
 module.exports.EncounterPerformed = EncounterPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/DiagnosisComponent":163,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],122:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/DiagnosisComponent":163,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],122:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34154,7 +34141,7 @@ class EncounterRecommended extends mongoose.Document {
 module.exports.EncounterRecommended = EncounterRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],123:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],123:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34200,7 +34187,7 @@ class FamilyHistory extends mongoose.Document {
 module.exports.FamilyHistory = FamilyHistory;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],124:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],124:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34251,7 +34238,7 @@ class ImmunizationAdministered extends mongoose.Document {
 module.exports.ImmunizationAdministered = ImmunizationAdministered;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],125:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],125:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34302,7 +34289,7 @@ class ImmunizationOrder extends mongoose.Document {
 module.exports.ImmunizationOrder = ImmunizationOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],126:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],126:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34349,7 +34336,7 @@ class InterventionOrder extends mongoose.Document {
 module.exports.InterventionOrder = InterventionOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],127:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],127:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34401,7 +34388,7 @@ class InterventionPerformed extends mongoose.Document {
 module.exports.InterventionPerformed = InterventionPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],128:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],128:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34448,7 +34435,7 @@ class InterventionRecommended extends mongoose.Document {
 module.exports.InterventionRecommended = InterventionRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],129:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],129:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34495,7 +34482,7 @@ class LaboratoryTestOrder extends mongoose.Document {
 module.exports.LaboratoryTestOrder = LaboratoryTestOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],130:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],130:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34552,7 +34539,7 @@ class LaboratoryTestPerformed extends mongoose.Document {
 module.exports.LaboratoryTestPerformed = LaboratoryTestPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],131:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],131:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34599,7 +34586,7 @@ class LaboratoryTestRecommended extends mongoose.Document {
 module.exports.LaboratoryTestRecommended = LaboratoryTestRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],132:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],132:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34648,7 +34635,7 @@ class MedicationActive extends mongoose.Document {
 module.exports.MedicationActive = MedicationActive;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],133:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],133:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34700,7 +34687,7 @@ class MedicationAdministered extends mongoose.Document {
 module.exports.MedicationAdministered = MedicationAdministered;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],134:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],134:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34753,7 +34740,7 @@ class MedicationDischarge extends mongoose.Document {
 module.exports.MedicationDischarge = MedicationDischarge;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],135:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],135:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34809,7 +34796,7 @@ class MedicationDispensed extends mongoose.Document {
 module.exports.MedicationDispensed = MedicationDispensed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],136:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],136:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34865,7 +34852,7 @@ class MedicationOrder extends mongoose.Document {
 module.exports.MedicationOrder = MedicationOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],137:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],137:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34908,7 +34895,7 @@ class Participation extends mongoose.Document {
 module.exports.Participation = Participation;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],138:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],138:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34952,7 +34939,7 @@ class PatientCareExperience extends mongoose.Document {
 module.exports.PatientCareExperience = PatientCareExperience;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],139:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],139:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -34995,7 +34982,7 @@ class PatientCharacteristic extends mongoose.Document {
 module.exports.PatientCharacteristic = PatientCharacteristic;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],140:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],140:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35039,7 +35026,7 @@ class PatientCharacteristicBirthdate extends mongoose.Document {
 module.exports.PatientCharacteristicBirthdate = PatientCharacteristicBirthdate;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],141:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],141:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35085,7 +35072,7 @@ class PatientCharacteristicClinicalTrialParticipant extends mongoose.Document {
 module.exports.PatientCharacteristicClinicalTrialParticipant = PatientCharacteristicClinicalTrialParticipant;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],142:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],142:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35128,7 +35115,7 @@ class PatientCharacteristicEthnicity extends mongoose.Document {
 module.exports.PatientCharacteristicEthnicity = PatientCharacteristicEthnicity;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],143:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],143:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35173,7 +35160,7 @@ class PatientCharacteristicExpired extends mongoose.Document {
 module.exports.PatientCharacteristicExpired = PatientCharacteristicExpired;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],144:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],144:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35217,7 +35204,7 @@ class PatientCharacteristicPayer extends mongoose.Document {
 module.exports.PatientCharacteristicPayer = PatientCharacteristicPayer;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],145:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],145:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35260,7 +35247,7 @@ class PatientCharacteristicRace extends mongoose.Document {
 module.exports.PatientCharacteristicRace = PatientCharacteristicRace;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],146:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],146:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35303,7 +35290,7 @@ class PatientCharacteristicSex extends mongoose.Document {
 module.exports.PatientCharacteristicSex = PatientCharacteristicSex;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],147:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],147:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35351,7 +35338,7 @@ class PhysicalExamOrder extends mongoose.Document {
 module.exports.PhysicalExamOrder = PhysicalExamOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],148:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],148:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35405,7 +35392,7 @@ class PhysicalExamPerformed extends mongoose.Document {
 module.exports.PhysicalExamPerformed = PhysicalExamPerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],149:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],149:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35453,7 +35440,7 @@ class PhysicalExamRecommended extends mongoose.Document {
 module.exports.PhysicalExamRecommended = PhysicalExamRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],150:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],150:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35503,7 +35490,7 @@ class ProcedureOrder extends mongoose.Document {
 module.exports.ProcedureOrder = ProcedureOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],151:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],151:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35560,7 +35547,7 @@ class ProcedurePerformed extends mongoose.Document {
 module.exports.ProcedurePerformed = ProcedurePerformed;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],152:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],152:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35609,7 +35596,7 @@ class ProcedureRecommended extends mongoose.Document {
 module.exports.ProcedureRecommended = ProcedureRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],153:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],153:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -35653,7 +35640,7 @@ class ProviderCareExperience extends mongoose.Document {
 module.exports.ProviderCareExperience = ProviderCareExperience;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],154:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],154:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('./basetypes/Code');
 const Interval = require('./basetypes/Interval');
@@ -35981,7 +35968,7 @@ class QDMPatient extends mongoose.Document {
 }
 module.exports.QDMPatient = QDMPatient;
 
-},{"./AllDataElements":107,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/Quantity":179,"mongoose/browser":219}],155:[function(require,module,exports){
+},{"./AllDataElements":107,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/Quantity":179,"mongoose/browser":227}],155:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -36025,7 +36012,7 @@ class RelatedPerson extends mongoose.Document {
 module.exports.RelatedPerson = RelatedPerson;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],156:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],156:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const PlaceholderResultSchema = mongoose.Schema({
@@ -36060,7 +36047,7 @@ class PlaceholderResult extends mongoose.Document {
 }
 module.exports.PlaceholderResult = PlaceholderResult;
 
-},{"mongoose/browser":219}],157:[function(require,module,exports){
+},{"mongoose/browser":227}],157:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -36111,7 +36098,7 @@ class SubstanceAdministered extends mongoose.Document {
 module.exports.SubstanceAdministered = SubstanceAdministered;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],158:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],158:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -36164,7 +36151,7 @@ class SubstanceOrder extends mongoose.Document {
 module.exports.SubstanceOrder = SubstanceOrder;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],159:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],159:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -36215,7 +36202,7 @@ class SubstanceRecommended extends mongoose.Document {
 module.exports.SubstanceRecommended = SubstanceRecommended;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],160:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],160:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./attributes/Identifier');
@@ -36261,7 +36248,7 @@ class Symptom extends mongoose.Document {
 module.exports.Symptom = Symptom;
 
 
-},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":219}],161:[function(require,module,exports){
+},{"./attributes/Component":162,"./attributes/Entity":164,"./attributes/FacilityLocation":165,"./attributes/Identifier":166,"./basetypes/Any":172,"./basetypes/AnyEntity":173,"./basetypes/Code":174,"./basetypes/DataElement":175,"./basetypes/DateTime":176,"./basetypes/Interval":177,"./basetypes/QDMDate":178,"./basetypes/Quantity":179,"mongoose/browser":227}],161:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { EntitySchemaFunction } = require('./Entity');
@@ -36296,7 +36283,7 @@ class CarePartner extends mongoose.Document {
 module.exports.CarePartner = CarePartner;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":219}],162:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":227}],162:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -36366,7 +36353,7 @@ function ComponentSchemaFunction(add, options) {
 module.exports.Component = Component;
 module.exports.ComponentSchemaFunction = ComponentSchemaFunction;
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"mongoose/browser":219}],163:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"mongoose/browser":227}],163:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -36402,7 +36389,7 @@ class DiagnosisComponent extends mongoose.Document {
 module.exports.DiagnosisComponent = DiagnosisComponent;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"mongoose/browser":219}],164:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"mongoose/browser":227}],164:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { IdentifierSchema } = require('./Identifier');
@@ -36479,7 +36466,7 @@ function EntitySchemaFunction(add, options) {
 module.exports.Entity = Entity;
 module.exports.EntitySchemaFunction = EntitySchemaFunction;
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Identifier":166,"mongoose/browser":219}],165:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Identifier":166,"mongoose/browser":227}],165:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const Code = require('../basetypes/Code');
@@ -36514,7 +36501,7 @@ class FacilityLocation extends mongoose.Document {
 module.exports.FacilityLocation = FacilityLocation;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"mongoose/browser":219}],166:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"mongoose/browser":227}],166:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [Number, String] = [
@@ -36539,7 +36526,7 @@ class Identifier extends mongoose.Document {
 }
 module.exports.Identifier = Identifier;
 
-},{"mongoose/browser":219}],167:[function(require,module,exports){
+},{"mongoose/browser":227}],167:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { EntitySchemaFunction } = require('./Entity');
@@ -36573,7 +36560,7 @@ class Location extends mongoose.Document {
 module.exports.Location = Location;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":219}],168:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":227}],168:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { EntitySchemaFunction } = require('./Entity');
@@ -36608,7 +36595,7 @@ class Organization extends mongoose.Document {
 module.exports.Organization = Organization;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":219}],169:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":227}],169:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { EntitySchemaFunction } = require('./Entity');
@@ -36642,7 +36629,7 @@ class PatientEntity extends mongoose.Document {
 module.exports.PatientEntity = PatientEntity;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":219}],170:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":227}],170:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { EntitySchemaFunction } = require('./Entity');
@@ -36679,7 +36666,7 @@ class Practitioner extends mongoose.Document {
 module.exports.Practitioner = Practitioner;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":219}],171:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Entity":164,"mongoose/browser":227}],171:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const { ComponentSchemaFunction } = require('./Component');
@@ -36712,7 +36699,7 @@ class ResultComponent extends mongoose.Document {
 module.exports.ResultComponent = ResultComponent;
 
 
-},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Component":162,"mongoose/browser":219}],172:[function(require,module,exports){
+},{"../basetypes/Any":172,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/QDMDate":178,"../basetypes/Quantity":179,"./Component":162,"mongoose/browser":227}],172:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -36797,7 +36784,7 @@ Any.prototype.cast = any => RecursiveCast(any);
 mongoose.Schema.Types.Any = Any;
 module.exports = Any;
 
-},{"cql-execution":54,"mongoose/browser":219}],173:[function(require,module,exports){
+},{"cql-execution":54,"mongoose/browser":227}],173:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { PatientEntity } = require('../attributes/PatientEntity');
 const { Practitioner } = require('../attributes/Practitioner');
@@ -36846,7 +36833,7 @@ AnyEntity.prototype.cast = (entity) => {
 mongoose.Schema.Types.AnyEntity = AnyEntity;
 module.exports = AnyEntity;
 
-},{"../attributes/CarePartner":161,"../attributes/Location":167,"../attributes/Organization":168,"../attributes/PatientEntity":169,"../attributes/Practitioner":170,"mongoose/browser":219}],174:[function(require,module,exports){
+},{"../attributes/CarePartner":161,"../attributes/Location":167,"../attributes/Organization":168,"../attributes/PatientEntity":169,"../attributes/Practitioner":170,"mongoose/browser":227}],174:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -36879,7 +36866,7 @@ Code.prototype.cast = (code) => {
 mongoose.Schema.Types.Code = Code;
 module.exports = Code;
 
-},{"cql-execution":54,"mongoose/browser":219}],175:[function(require,module,exports){
+},{"cql-execution":54,"mongoose/browser":227}],175:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 const Code = require('./Code.js');
@@ -36961,7 +36948,7 @@ function DataElementSchema(add, options) {
 
 module.exports.DataElementSchema = DataElementSchema;
 
-},{"../attributes/Identifier":166,"./Code.js":174,"cql-execution":54,"mongoose/browser":219}],176:[function(require,module,exports){
+},{"../attributes/Identifier":166,"./Code.js":174,"cql-execution":54,"mongoose/browser":227}],176:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -36985,7 +36972,7 @@ DateTime.prototype.cast = (dateTime) => {
 mongoose.Schema.Types.DateTime = DateTime;
 module.exports = DateTime;
 
-},{"cql-execution":54,"mongoose/browser":219}],177:[function(require,module,exports){
+},{"cql-execution":54,"mongoose/browser":227}],177:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 const DateTime = require('./DateTime');
@@ -37024,7 +37011,7 @@ Interval.prototype.cast = (interval) => {
 mongoose.Schema.Types.Interval = Interval;
 module.exports = Interval;
 
-},{"./DateTime":176,"cql-execution":54,"mongoose/browser":219}],178:[function(require,module,exports){
+},{"./DateTime":176,"cql-execution":54,"mongoose/browser":227}],178:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -37062,7 +37049,7 @@ QDMDate.prototype.cast = (date) => {
 mongoose.Schema.Types.QDMDate = QDMDate;
 module.exports = QDMDate;
 
-},{"cql-execution":54,"mongoose/browser":219}],179:[function(require,module,exports){
+},{"cql-execution":54,"mongoose/browser":227}],179:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const cql = require('cql-execution');
 
@@ -37084,7 +37071,7 @@ Quantity.prototype.cast = (quantity) => {
 mongoose.Schema.Types.Quantity = Quantity;
 module.exports = Quantity;
 
-},{"cql-execution":54,"mongoose/browser":219}],180:[function(require,module,exports){
+},{"cql-execution":54,"mongoose/browser":227}],180:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { StatementDependencySchema } = require('./CQLStatementDependency');
 
@@ -37118,7 +37105,7 @@ class CQLLibrary extends mongoose.Document {
 }
 module.exports.CQLLibrary = CQLLibrary;
 
-},{"./CQLStatementDependency":181,"mongoose/browser":219}],181:[function(require,module,exports){
+},{"./CQLStatementDependency":181,"mongoose/browser":227}],181:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const StatementReferenceSchema = new mongoose.Schema({
@@ -37148,7 +37135,7 @@ class StatementDependency extends mongoose.Document {
 }
 module.exports.StatementDependency = StatementDependency;
 
-},{"mongoose/browser":219}],182:[function(require,module,exports){
+},{"mongoose/browser":227}],182:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [String, Mixed] = [
@@ -37178,7 +37165,7 @@ class ClauseResult extends mongoose.Document {
 }
 module.exports.ClauseResult = ClauseResult;
 
-},{"mongoose/browser":219}],183:[function(require,module,exports){
+},{"mongoose/browser":227}],183:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const ConceptSchema = new mongoose.Schema({
@@ -37197,7 +37184,7 @@ class Concept extends mongoose.Document {
 }
 module.exports.Concept = Concept;
 
-},{"mongoose/browser":219}],184:[function(require,module,exports){
+},{"mongoose/browser":227}],184:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const { ClauseResultSchema } = require('./ClauseResult');
 const { StatementResultSchema } = require('./StatementResult');
@@ -37287,7 +37274,7 @@ class IndividualResult extends mongoose.Document {
 }
 module.exports.IndividualResult = IndividualResult;
 
-},{"./ClauseResult":182,"./StatementResult":190,"mongoose/browser":219}],185:[function(require,module,exports){
+},{"./ClauseResult":182,"./StatementResult":190,"mongoose/browser":227}],185:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
@@ -37397,7 +37384,7 @@ class Measure extends mongoose.Document {
 }
 module.exports.Measure = Measure;
 
-},{"../AllDataElements":107,"../basetypes/Code":174,"../basetypes/DataElement":175,"../basetypes/Interval":177,"../basetypes/Quantity":179,"./CQLLibrary":180,"./PopulationSet":188,"mongoose/browser":219}],186:[function(require,module,exports){
+},{"../AllDataElements":107,"../basetypes/Code":174,"../basetypes/DataElement":175,"../basetypes/Interval":177,"../basetypes/Quantity":179,"./CQLLibrary":180,"./PopulationSet":188,"mongoose/browser":227}],186:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 // using mBuffer to not conflict with system Buffer
@@ -37425,7 +37412,7 @@ class MeasurePackage extends mongoose.Document {
 }
 module.exports.MeasurePackage = MeasurePackage;
 
-},{"mongoose/browser":219}],187:[function(require,module,exports){
+},{"mongoose/browser":227}],187:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Code = require('../basetypes/Code');
 const Interval = require('../basetypes/Interval');
@@ -37465,7 +37452,7 @@ class Patient extends mongoose.Document {
 }
 module.exports.Patient = Patient;
 
-},{"../QDMPatient":154,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/Quantity":179,"./Provider":189,"mongoose/browser":219}],188:[function(require,module,exports){
+},{"../QDMPatient":154,"../basetypes/Code":174,"../basetypes/DateTime":176,"../basetypes/Interval":177,"../basetypes/Quantity":179,"./Provider":189,"mongoose/browser":227}],188:[function(require,module,exports){
 /* eslint-disable no-unused-vars, no-param-reassign */
 const mongoose = require('mongoose/browser');
 const { StatementReferenceSchema } = require('./CQLStatementDependency');
@@ -37555,7 +37542,7 @@ class PopulationSet extends mongoose.Document {
 }
 module.exports.PopulationSet = PopulationSet;
 
-},{"./CQLStatementDependency":181,"mongoose/browser":219}],189:[function(require,module,exports){
+},{"./CQLStatementDependency":181,"mongoose/browser":227}],189:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [Schema, String, Boolean] = [
@@ -37599,7 +37586,7 @@ class Provider extends mongoose.Document {
 }
 module.exports.Provider = Provider;
 
-},{"mongoose/browser":219}],190:[function(require,module,exports){
+},{"mongoose/browser":227}],190:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 
 const [String, Mixed] = [
@@ -37642,7 +37629,7 @@ class StatementResult extends mongoose.Document {
 }
 module.exports.StatementResult = StatementResult;
 
-},{"mongoose/browser":219}],191:[function(require,module,exports){
+},{"mongoose/browser":227}],191:[function(require,module,exports){
 const mongoose = require('mongoose/browser');
 const Concept = require('./Concept.js');
 
@@ -37670,7 +37657,7 @@ class ValueSet extends mongoose.Document {
 }
 module.exports.ValueSet = ValueSet;
 
-},{"./Concept.js":183,"mongoose/browser":219}],192:[function(require,module,exports){
+},{"./Concept.js":183,"mongoose/browser":227}],192:[function(require,module,exports){
 module.exports = require('./AllDataElements.js');
 module.exports.CQL = require('cql-execution');
 module.exports.Result = require('./Result.js').Result;
@@ -37703,26 +37690,14 @@ module.exports.StatementResultSchema = require('./cqm/StatementResult.js').State
 },{"./AllDataElements.js":107,"./Result.js":156,"./cqm/CQLLibrary.js":180,"./cqm/CQLStatementDependency.js":181,"./cqm/ClauseResult.js":182,"./cqm/Concept.js":183,"./cqm/IndividualResult.js":184,"./cqm/Measure.js":185,"./cqm/MeasurePackage.js":186,"./cqm/Patient.js":187,"./cqm/PopulationSet.js":188,"./cqm/Provider.js":189,"./cqm/StatementResult.js":190,"./cqm/ValueSet.js":191,"cql-execution":54}],193:[function(require,module,exports){
 'use strict';
 
-var hasPropertyDescriptors = require('has-property-descriptors')();
+var $defineProperty = require('es-define-property');
 
-var GetIntrinsic = require('get-intrinsic');
-
-var $defineProperty = hasPropertyDescriptors && GetIntrinsic('%Object.defineProperty%', true);
-if ($defineProperty) {
-	try {
-		$defineProperty({}, 'a', { value: 1 });
-	} catch (e) {
-		// IE 8 has a broken defineProperty
-		$defineProperty = false;
-	}
-}
-
-var $SyntaxError = GetIntrinsic('%SyntaxError%');
-var $TypeError = GetIntrinsic('%TypeError%');
+var $SyntaxError = require('es-errors/syntax');
+var $TypeError = require('es-errors/type');
 
 var gopd = require('gopd');
 
-/** @type {(obj: Record<PropertyKey, unknown>, property: PropertyKey, value: unknown, nonEnumerable?: boolean | null, nonWritable?: boolean | null, nonConfigurable?: boolean | null, loose?: boolean) => void} */
+/** @type {import('.')} */
 module.exports = function defineDataProperty(
 	obj,
 	property,
@@ -37770,7 +37745,67 @@ module.exports = function defineDataProperty(
 	}
 };
 
-},{"get-intrinsic":198,"gopd":199,"has-property-descriptors":200}],194:[function(require,module,exports){
+},{"es-define-property":194,"es-errors/syntax":199,"es-errors/type":200,"gopd":207}],194:[function(require,module,exports){
+'use strict';
+
+var GetIntrinsic = require('get-intrinsic');
+
+/** @type {import('.')} */
+var $defineProperty = GetIntrinsic('%Object.defineProperty%', true) || false;
+if ($defineProperty) {
+	try {
+		$defineProperty({}, 'a', { value: 1 });
+	} catch (e) {
+		// IE 8 has a broken defineProperty
+		$defineProperty = false;
+	}
+}
+
+module.exports = $defineProperty;
+
+},{"get-intrinsic":206}],195:[function(require,module,exports){
+'use strict';
+
+/** @type {import('./eval')} */
+module.exports = EvalError;
+
+},{}],196:[function(require,module,exports){
+'use strict';
+
+/** @type {import('.')} */
+module.exports = Error;
+
+},{}],197:[function(require,module,exports){
+'use strict';
+
+/** @type {import('./range')} */
+module.exports = RangeError;
+
+},{}],198:[function(require,module,exports){
+'use strict';
+
+/** @type {import('./ref')} */
+module.exports = ReferenceError;
+
+},{}],199:[function(require,module,exports){
+'use strict';
+
+/** @type {import('./syntax')} */
+module.exports = SyntaxError;
+
+},{}],200:[function(require,module,exports){
+'use strict';
+
+/** @type {import('./type')} */
+module.exports = TypeError;
+
+},{}],201:[function(require,module,exports){
+'use strict';
+
+/** @type {import('./uri')} */
+module.exports = URIError;
+
+},{}],202:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -38269,7 +38304,7 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
   }
 }
 
-},{}],195:[function(require,module,exports){
+},{}],203:[function(require,module,exports){
 'use strict';
 
 var isCallable = require('is-callable');
@@ -38333,7 +38368,7 @@ var forEach = function forEach(list, iterator, thisArg) {
 
 module.exports = forEach;
 
-},{"is-callable":210}],196:[function(require,module,exports){
+},{"is-callable":218}],204:[function(require,module,exports){
 'use strict';
 
 /* eslint no-invalid-this: 1 */
@@ -38419,21 +38454,27 @@ module.exports = function bind(that) {
     return bound;
 };
 
-},{}],197:[function(require,module,exports){
+},{}],205:[function(require,module,exports){
 'use strict';
 
 var implementation = require('./implementation');
 
 module.exports = Function.prototype.bind || implementation;
 
-},{"./implementation":196}],198:[function(require,module,exports){
+},{"./implementation":204}],206:[function(require,module,exports){
 'use strict';
 
 var undefined;
 
-var $SyntaxError = SyntaxError;
+var $Error = require('es-errors');
+var $EvalError = require('es-errors/eval');
+var $RangeError = require('es-errors/range');
+var $ReferenceError = require('es-errors/ref');
+var $SyntaxError = require('es-errors/syntax');
+var $TypeError = require('es-errors/type');
+var $URIError = require('es-errors/uri');
+
 var $Function = Function;
-var $TypeError = TypeError;
 
 // eslint-disable-next-line consistent-return
 var getEvalledConstructor = function (expressionSyntax) {
@@ -38485,6 +38526,7 @@ var needsEval = {};
 var TypedArray = typeof Uint8Array === 'undefined' || !getProto ? undefined : getProto(Uint8Array);
 
 var INTRINSICS = {
+	__proto__: null,
 	'%AggregateError%': typeof AggregateError === 'undefined' ? undefined : AggregateError,
 	'%Array%': Array,
 	'%ArrayBuffer%': typeof ArrayBuffer === 'undefined' ? undefined : ArrayBuffer,
@@ -38505,9 +38547,9 @@ var INTRINSICS = {
 	'%decodeURIComponent%': decodeURIComponent,
 	'%encodeURI%': encodeURI,
 	'%encodeURIComponent%': encodeURIComponent,
-	'%Error%': Error,
+	'%Error%': $Error,
 	'%eval%': eval, // eslint-disable-line no-eval
-	'%EvalError%': EvalError,
+	'%EvalError%': $EvalError,
 	'%Float32Array%': typeof Float32Array === 'undefined' ? undefined : Float32Array,
 	'%Float64Array%': typeof Float64Array === 'undefined' ? undefined : Float64Array,
 	'%FinalizationRegistry%': typeof FinalizationRegistry === 'undefined' ? undefined : FinalizationRegistry,
@@ -38529,8 +38571,8 @@ var INTRINSICS = {
 	'%parseInt%': parseInt,
 	'%Promise%': typeof Promise === 'undefined' ? undefined : Promise,
 	'%Proxy%': typeof Proxy === 'undefined' ? undefined : Proxy,
-	'%RangeError%': RangeError,
-	'%ReferenceError%': ReferenceError,
+	'%RangeError%': $RangeError,
+	'%ReferenceError%': $ReferenceError,
 	'%Reflect%': typeof Reflect === 'undefined' ? undefined : Reflect,
 	'%RegExp%': RegExp,
 	'%Set%': typeof Set === 'undefined' ? undefined : Set,
@@ -38547,7 +38589,7 @@ var INTRINSICS = {
 	'%Uint8ClampedArray%': typeof Uint8ClampedArray === 'undefined' ? undefined : Uint8ClampedArray,
 	'%Uint16Array%': typeof Uint16Array === 'undefined' ? undefined : Uint16Array,
 	'%Uint32Array%': typeof Uint32Array === 'undefined' ? undefined : Uint32Array,
-	'%URIError%': URIError,
+	'%URIError%': $URIError,
 	'%WeakMap%': typeof WeakMap === 'undefined' ? undefined : WeakMap,
 	'%WeakRef%': typeof WeakRef === 'undefined' ? undefined : WeakRef,
 	'%WeakSet%': typeof WeakSet === 'undefined' ? undefined : WeakSet
@@ -38589,6 +38631,7 @@ var doEval = function doEval(name) {
 };
 
 var LEGACY_ALIASES = {
+	__proto__: null,
 	'%ArrayBufferPrototype%': ['ArrayBuffer', 'prototype'],
 	'%ArrayPrototype%': ['Array', 'prototype'],
 	'%ArrayProto_entries%': ['Array', 'prototype', 'entries'],
@@ -38779,7 +38822,7 @@ module.exports = function GetIntrinsic(name, allowMissing) {
 	return value;
 };
 
-},{"function-bind":197,"has-proto":201,"has-symbols":202,"hasown":205}],199:[function(require,module,exports){
+},{"es-errors":196,"es-errors/eval":195,"es-errors/range":197,"es-errors/ref":198,"es-errors/syntax":199,"es-errors/type":200,"es-errors/uri":201,"function-bind":205,"has-proto":209,"has-symbols":210,"hasown":213}],207:[function(require,module,exports){
 'use strict';
 
 var GetIntrinsic = require('get-intrinsic');
@@ -38797,29 +38840,18 @@ if ($gOPD) {
 
 module.exports = $gOPD;
 
-},{"get-intrinsic":198}],200:[function(require,module,exports){
+},{"get-intrinsic":206}],208:[function(require,module,exports){
 'use strict';
 
-var GetIntrinsic = require('get-intrinsic');
-
-var $defineProperty = GetIntrinsic('%Object.defineProperty%', true);
+var $defineProperty = require('es-define-property');
 
 var hasPropertyDescriptors = function hasPropertyDescriptors() {
-	if ($defineProperty) {
-		try {
-			$defineProperty({}, 'a', { value: 1 });
-			return true;
-		} catch (e) {
-			// IE 8 has a broken defineProperty
-			return false;
-		}
-	}
-	return false;
+	return !!$defineProperty;
 };
 
 hasPropertyDescriptors.hasArrayLengthDefineBug = function hasArrayLengthDefineBug() {
 	// node v0.6 has a bug where array lengths can be Set but not Defined
-	if (!hasPropertyDescriptors()) {
+	if (!$defineProperty) {
 		return null;
 	}
 	try {
@@ -38832,20 +38864,24 @@ hasPropertyDescriptors.hasArrayLengthDefineBug = function hasArrayLengthDefineBu
 
 module.exports = hasPropertyDescriptors;
 
-},{"get-intrinsic":198}],201:[function(require,module,exports){
+},{"es-define-property":194}],209:[function(require,module,exports){
 'use strict';
 
 var test = {
+	__proto__: null,
 	foo: {}
 };
 
 var $Object = Object;
 
+/** @type {import('.')} */
 module.exports = function hasProto() {
-	return { __proto__: test }.foo === test.foo && !({ __proto__: null } instanceof $Object);
+	// @ts-expect-error: TS errors on an inherited property for some reason
+	return { __proto__: test }.foo === test.foo
+		&& !(test instanceof $Object);
 };
 
-},{}],202:[function(require,module,exports){
+},{}],210:[function(require,module,exports){
 'use strict';
 
 var origSymbol = typeof Symbol !== 'undefined' && Symbol;
@@ -38860,7 +38896,7 @@ module.exports = function hasNativeSymbols() {
 	return hasSymbolSham();
 };
 
-},{"./shams":203}],203:[function(require,module,exports){
+},{"./shams":211}],211:[function(require,module,exports){
 'use strict';
 
 /* eslint complexity: [2, 18], max-statements: [2, 33] */
@@ -38904,26 +38940,27 @@ module.exports = function hasSymbols() {
 	return true;
 };
 
-},{}],204:[function(require,module,exports){
+},{}],212:[function(require,module,exports){
 'use strict';
 
 var hasSymbols = require('has-symbols/shams');
 
+/** @type {import('.')} */
 module.exports = function hasToStringTagShams() {
 	return hasSymbols() && !!Symbol.toStringTag;
 };
 
-},{"has-symbols/shams":203}],205:[function(require,module,exports){
+},{"has-symbols/shams":211}],213:[function(require,module,exports){
 'use strict';
 
 var call = Function.prototype.call;
 var $hasOwn = Object.prototype.hasOwnProperty;
 var bind = require('function-bind');
 
-/** @type {(o: {}, p: PropertyKey) => p is keyof o} */
+/** @type {import('.')} */
 module.exports = bind.call(call, $hasOwn);
 
-},{"function-bind":197}],206:[function(require,module,exports){
+},{"function-bind":205}],214:[function(require,module,exports){
 /*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> */
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
@@ -39010,7 +39047,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],207:[function(require,module,exports){
+},{}],215:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -39039,7 +39076,7 @@ if (typeof Object.create === 'function') {
   }
 }
 
-},{}],208:[function(require,module,exports){
+},{}],216:[function(require,module,exports){
 'use strict';
 
 var hasToStringTag = require('has-tostringtag/shams')();
@@ -39074,7 +39111,7 @@ isStandardArguments.isLegacyArguments = isLegacyArguments; // for tests
 
 module.exports = supportsStandardArguments ? isStandardArguments : isLegacyArguments;
 
-},{"call-bind/callBound":50,"has-tostringtag/shams":204}],209:[function(require,module,exports){
+},{"call-bind/callBound":50,"has-tostringtag/shams":212}],217:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -39097,7 +39134,7 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],210:[function(require,module,exports){
+},{}],218:[function(require,module,exports){
 'use strict';
 
 var fnToStr = Function.prototype.toString;
@@ -39200,14 +39237,14 @@ module.exports = reflectApply
 		return tryFunctionObject(value);
 	};
 
-},{}],211:[function(require,module,exports){
+},{}],219:[function(require,module,exports){
 'use strict';
 
 module.exports = Number.isFinite || function (value) {
 	return !(typeof value !== 'number' || value !== value || value === Infinity || value === -Infinity);
 };
 
-},{}],212:[function(require,module,exports){
+},{}],220:[function(require,module,exports){
 'use strict';
 
 var toStr = Object.prototype.toString;
@@ -39247,7 +39284,7 @@ module.exports = function isGeneratorFunction(fn) {
 	return getProto(fn) === GeneratorFunction;
 };
 
-},{"has-tostringtag/shams":204}],213:[function(require,module,exports){
+},{"has-tostringtag/shams":212}],221:[function(require,module,exports){
 // https://github.com/paulmillr/es6-shim
 // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.isinteger
 var isFinite = require("is-finite");
@@ -39257,16 +39294,17 @@ module.exports = Number.isInteger || function(val) {
     Math.floor(val) === val;
 };
 
-},{"is-finite":211}],214:[function(require,module,exports){
+},{"is-finite":219}],222:[function(require,module,exports){
 'use strict';
 
 var whichTypedArray = require('which-typed-array');
 
+/** @type {import('.')} */
 module.exports = function isTypedArray(value) {
 	return !!whichTypedArray(value);
 };
 
-},{"which-typed-array":371}],215:[function(require,module,exports){
+},{"which-typed-array":384}],223:[function(require,module,exports){
 (function (process){(function (){
 'use strict';
 
@@ -39782,7 +39820,7 @@ function decorateNextFn(fn) {
 module.exports = Kareem;
 
 }).call(this)}).call(this,require('_process'))
-},{"_process":362}],216:[function(require,module,exports){
+},{"_process":375}],224:[function(require,module,exports){
 (function (global){(function (){
 /**
  * @license
@@ -56995,7 +57033,7 @@ module.exports = Kareem;
 }.call(this));
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],217:[function(require,module,exports){
+},{}],225:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -65484,9 +65522,9 @@ exports.VERSION = VERSION;
 exports.Zone = Zone;
 
 
-},{}],218:[function(require,module,exports){
+},{}],226:[function(require,module,exports){
 //! moment.js
-//! version : 2.29.4
+//! version : 2.30.1
 //! authors : Tim Wood, Iskren Chernev, Moment.js contributors
 //! license : MIT
 //! momentjs.com
@@ -65642,24 +65680,25 @@ exports.Zone = Zone;
     }
 
     function isValid(m) {
-        if (m._isValid == null) {
-            var flags = getParsingFlags(m),
-                parsedParts = some.call(flags.parsedDateParts, function (i) {
-                    return i != null;
-                }),
-                isNowValid =
-                    !isNaN(m._d.getTime()) &&
-                    flags.overflow < 0 &&
-                    !flags.empty &&
-                    !flags.invalidEra &&
-                    !flags.invalidMonth &&
-                    !flags.invalidWeekday &&
-                    !flags.weekdayMismatch &&
-                    !flags.nullInput &&
-                    !flags.invalidFormat &&
-                    !flags.userInvalidated &&
-                    (!flags.meridiem || (flags.meridiem && parsedParts));
-
+        var flags = null,
+            parsedParts = false,
+            isNowValid = m._d && !isNaN(m._d.getTime());
+        if (isNowValid) {
+            flags = getParsingFlags(m);
+            parsedParts = some.call(flags.parsedDateParts, function (i) {
+                return i != null;
+            });
+            isNowValid =
+                flags.overflow < 0 &&
+                !flags.empty &&
+                !flags.invalidEra &&
+                !flags.invalidMonth &&
+                !flags.invalidWeekday &&
+                !flags.weekdayMismatch &&
+                !flags.nullInput &&
+                !flags.invalidFormat &&
+                !flags.userInvalidated &&
+                (!flags.meridiem || (flags.meridiem && parsedParts));
             if (m._strict) {
                 isNowValid =
                     isNowValid &&
@@ -65667,12 +65706,11 @@ exports.Zone = Zone;
                     flags.unusedTokens.length === 0 &&
                     flags.bigHour === undefined;
             }
-
-            if (Object.isFrozen == null || !Object.isFrozen(m)) {
-                m._isValid = isNowValid;
-            } else {
-                return isNowValid;
-            }
+        }
+        if (Object.isFrozen == null || !Object.isFrozen(m)) {
+            m._isValid = isNowValid;
+        } else {
+            return isNowValid;
         }
         return m._isValid;
     }
@@ -66117,12 +66155,56 @@ exports.Zone = Zone;
         return isFunction(format) ? format(output) : format.replace(/%s/i, output);
     }
 
-    var aliases = {};
-
-    function addUnitAlias(unit, shorthand) {
-        var lowerCase = unit.toLowerCase();
-        aliases[lowerCase] = aliases[lowerCase + 's'] = aliases[shorthand] = unit;
-    }
+    var aliases = {
+        D: 'date',
+        dates: 'date',
+        date: 'date',
+        d: 'day',
+        days: 'day',
+        day: 'day',
+        e: 'weekday',
+        weekdays: 'weekday',
+        weekday: 'weekday',
+        E: 'isoWeekday',
+        isoweekdays: 'isoWeekday',
+        isoweekday: 'isoWeekday',
+        DDD: 'dayOfYear',
+        dayofyears: 'dayOfYear',
+        dayofyear: 'dayOfYear',
+        h: 'hour',
+        hours: 'hour',
+        hour: 'hour',
+        ms: 'millisecond',
+        milliseconds: 'millisecond',
+        millisecond: 'millisecond',
+        m: 'minute',
+        minutes: 'minute',
+        minute: 'minute',
+        M: 'month',
+        months: 'month',
+        month: 'month',
+        Q: 'quarter',
+        quarters: 'quarter',
+        quarter: 'quarter',
+        s: 'second',
+        seconds: 'second',
+        second: 'second',
+        gg: 'weekYear',
+        weekyears: 'weekYear',
+        weekyear: 'weekYear',
+        GG: 'isoWeekYear',
+        isoweekyears: 'isoWeekYear',
+        isoweekyear: 'isoWeekYear',
+        w: 'week',
+        weeks: 'week',
+        week: 'week',
+        W: 'isoWeek',
+        isoweeks: 'isoWeek',
+        isoweek: 'isoWeek',
+        y: 'year',
+        years: 'year',
+        year: 'year',
+    };
 
     function normalizeUnits(units) {
         return typeof units === 'string'
@@ -66147,11 +66229,24 @@ exports.Zone = Zone;
         return normalizedInput;
     }
 
-    var priorities = {};
-
-    function addUnitPriority(unit, priority) {
-        priorities[unit] = priority;
-    }
+    var priorities = {
+        date: 9,
+        day: 11,
+        weekday: 11,
+        isoWeekday: 11,
+        dayOfYear: 4,
+        hour: 13,
+        millisecond: 16,
+        minute: 14,
+        month: 8,
+        quarter: 7,
+        second: 15,
+        weekYear: 1,
+        isoWeekYear: 1,
+        week: 5,
+        isoWeek: 5,
+        year: 1,
+    };
 
     function getPrioritizedUnits(unitsObj) {
         var units = [],
@@ -66165,96 +66260,6 @@ exports.Zone = Zone;
             return a.priority - b.priority;
         });
         return units;
-    }
-
-    function isLeapYear(year) {
-        return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-    }
-
-    function absFloor(number) {
-        if (number < 0) {
-            // -0 -> 0
-            return Math.ceil(number) || 0;
-        } else {
-            return Math.floor(number);
-        }
-    }
-
-    function toInt(argumentForCoercion) {
-        var coercedNumber = +argumentForCoercion,
-            value = 0;
-
-        if (coercedNumber !== 0 && isFinite(coercedNumber)) {
-            value = absFloor(coercedNumber);
-        }
-
-        return value;
-    }
-
-    function makeGetSet(unit, keepTime) {
-        return function (value) {
-            if (value != null) {
-                set$1(this, unit, value);
-                hooks.updateOffset(this, keepTime);
-                return this;
-            } else {
-                return get(this, unit);
-            }
-        };
-    }
-
-    function get(mom, unit) {
-        return mom.isValid()
-            ? mom._d['get' + (mom._isUTC ? 'UTC' : '') + unit]()
-            : NaN;
-    }
-
-    function set$1(mom, unit, value) {
-        if (mom.isValid() && !isNaN(value)) {
-            if (
-                unit === 'FullYear' &&
-                isLeapYear(mom.year()) &&
-                mom.month() === 1 &&
-                mom.date() === 29
-            ) {
-                value = toInt(value);
-                mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](
-                    value,
-                    mom.month(),
-                    daysInMonth(value, mom.month())
-                );
-            } else {
-                mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
-            }
-        }
-    }
-
-    // MOMENTS
-
-    function stringGet(units) {
-        units = normalizeUnits(units);
-        if (isFunction(this[units])) {
-            return this[units]();
-        }
-        return this;
-    }
-
-    function stringSet(units, value) {
-        if (typeof units === 'object') {
-            units = normalizeObjectUnits(units);
-            var prioritized = getPrioritizedUnits(units),
-                i,
-                prioritizedLen = prioritized.length;
-            for (i = 0; i < prioritizedLen; i++) {
-                this[prioritized[i].unit](units[prioritized[i].unit]);
-            }
-        } else {
-            units = normalizeUnits(units);
-            if (isFunction(this[units])) {
-                return this[units](value);
-            }
-        }
-        return this;
     }
 
     var match1 = /\d/, //       0 - 9
@@ -66277,6 +66282,8 @@ exports.Zone = Zone;
         // includes scottish gaelic two word and hyphenated months
         matchWord =
             /[0-9]{0,256}['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFF07\uFF10-\uFFEF]{1,256}|[\u0600-\u06FF\/]{1,256}(\s*?[\u0600-\u06FF]{1,256}){1,2}/i,
+        match1to2NoLeadingZero = /^[1-9]\d?/, //         1-99
+        match1to2HasZero = /^([1-9]\d|\d)/, //           0-99
         regexes;
 
     regexes = {};
@@ -66315,6 +66322,26 @@ exports.Zone = Zone;
         return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     }
 
+    function absFloor(number) {
+        if (number < 0) {
+            // -0 -> 0
+            return Math.ceil(number) || 0;
+        } else {
+            return Math.floor(number);
+        }
+    }
+
+    function toInt(argumentForCoercion) {
+        var coercedNumber = +argumentForCoercion,
+            value = 0;
+
+        if (coercedNumber !== 0 && isFinite(coercedNumber)) {
+            value = absFloor(coercedNumber);
+        }
+
+        return value;
+    }
+
     var tokens = {};
 
     function addParseToken(token, callback) {
@@ -66348,6 +66375,10 @@ exports.Zone = Zone;
         }
     }
 
+    function isLeapYear(year) {
+        return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    }
+
     var YEAR = 0,
         MONTH = 1,
         DATE = 2,
@@ -66357,6 +66388,173 @@ exports.Zone = Zone;
         MILLISECOND = 6,
         WEEK = 7,
         WEEKDAY = 8;
+
+    // FORMATTING
+
+    addFormatToken('Y', 0, 0, function () {
+        var y = this.year();
+        return y <= 9999 ? zeroFill(y, 4) : '+' + y;
+    });
+
+    addFormatToken(0, ['YY', 2], 0, function () {
+        return this.year() % 100;
+    });
+
+    addFormatToken(0, ['YYYY', 4], 0, 'year');
+    addFormatToken(0, ['YYYYY', 5], 0, 'year');
+    addFormatToken(0, ['YYYYYY', 6, true], 0, 'year');
+
+    // PARSING
+
+    addRegexToken('Y', matchSigned);
+    addRegexToken('YY', match1to2, match2);
+    addRegexToken('YYYY', match1to4, match4);
+    addRegexToken('YYYYY', match1to6, match6);
+    addRegexToken('YYYYYY', match1to6, match6);
+
+    addParseToken(['YYYYY', 'YYYYYY'], YEAR);
+    addParseToken('YYYY', function (input, array) {
+        array[YEAR] =
+            input.length === 2 ? hooks.parseTwoDigitYear(input) : toInt(input);
+    });
+    addParseToken('YY', function (input, array) {
+        array[YEAR] = hooks.parseTwoDigitYear(input);
+    });
+    addParseToken('Y', function (input, array) {
+        array[YEAR] = parseInt(input, 10);
+    });
+
+    // HELPERS
+
+    function daysInYear(year) {
+        return isLeapYear(year) ? 366 : 365;
+    }
+
+    // HOOKS
+
+    hooks.parseTwoDigitYear = function (input) {
+        return toInt(input) + (toInt(input) > 68 ? 1900 : 2000);
+    };
+
+    // MOMENTS
+
+    var getSetYear = makeGetSet('FullYear', true);
+
+    function getIsLeapYear() {
+        return isLeapYear(this.year());
+    }
+
+    function makeGetSet(unit, keepTime) {
+        return function (value) {
+            if (value != null) {
+                set$1(this, unit, value);
+                hooks.updateOffset(this, keepTime);
+                return this;
+            } else {
+                return get(this, unit);
+            }
+        };
+    }
+
+    function get(mom, unit) {
+        if (!mom.isValid()) {
+            return NaN;
+        }
+
+        var d = mom._d,
+            isUTC = mom._isUTC;
+
+        switch (unit) {
+            case 'Milliseconds':
+                return isUTC ? d.getUTCMilliseconds() : d.getMilliseconds();
+            case 'Seconds':
+                return isUTC ? d.getUTCSeconds() : d.getSeconds();
+            case 'Minutes':
+                return isUTC ? d.getUTCMinutes() : d.getMinutes();
+            case 'Hours':
+                return isUTC ? d.getUTCHours() : d.getHours();
+            case 'MongooseDate':
+                return isUTC ? d.getUTCDate() : d.getDate();
+            case 'Day':
+                return isUTC ? d.getUTCDay() : d.getDay();
+            case 'Month':
+                return isUTC ? d.getUTCMonth() : d.getMonth();
+            case 'FullYear':
+                return isUTC ? d.getUTCFullYear() : d.getFullYear();
+            default:
+                return NaN; // Just in case
+        }
+    }
+
+    function set$1(mom, unit, value) {
+        var d, isUTC, year, month, date;
+
+        if (!mom.isValid() || isNaN(value)) {
+            return;
+        }
+
+        d = mom._d;
+        isUTC = mom._isUTC;
+
+        switch (unit) {
+            case 'Milliseconds':
+                return void (isUTC
+                    ? d.setUTCMilliseconds(value)
+                    : d.setMilliseconds(value));
+            case 'Seconds':
+                return void (isUTC ? d.setUTCSeconds(value) : d.setSeconds(value));
+            case 'Minutes':
+                return void (isUTC ? d.setUTCMinutes(value) : d.setMinutes(value));
+            case 'Hours':
+                return void (isUTC ? d.setUTCHours(value) : d.setHours(value));
+            case 'MongooseDate':
+                return void (isUTC ? d.setUTCDate(value) : d.setDate(value));
+            // case 'Day': // Not real
+            //    return void (isUTC ? d.setUTCDay(value) : d.setDay(value));
+            // case 'Month': // Not used because we need to pass two variables
+            //     return void (isUTC ? d.setUTCMonth(value) : d.setMonth(value));
+            case 'FullYear':
+                break; // See below ...
+            default:
+                return; // Just in case
+        }
+
+        year = value;
+        month = mom.month();
+        date = mom.date();
+        date = date === 29 && month === 1 && !isLeapYear(year) ? 28 : date;
+        void (isUTC
+            ? d.setUTCFullYear(year, month, date)
+            : d.setFullYear(year, month, date));
+    }
+
+    // MOMENTS
+
+    function stringGet(units) {
+        units = normalizeUnits(units);
+        if (isFunction(this[units])) {
+            return this[units]();
+        }
+        return this;
+    }
+
+    function stringSet(units, value) {
+        if (typeof units === 'object') {
+            units = normalizeObjectUnits(units);
+            var prioritized = getPrioritizedUnits(units),
+                i,
+                prioritizedLen = prioritized.length;
+            for (i = 0; i < prioritizedLen; i++) {
+                this[prioritized[i].unit](units[prioritized[i].unit]);
+            }
+        } else {
+            units = normalizeUnits(units);
+            if (isFunction(this[units])) {
+                return this[units](value);
+            }
+        }
+        return this;
+    }
 
     function mod(n, x) {
         return ((n % x) + x) % x;
@@ -66406,17 +66604,9 @@ exports.Zone = Zone;
         return this.localeData().months(this, format);
     });
 
-    // ALIASES
-
-    addUnitAlias('month', 'M');
-
-    // PRIORITY
-
-    addUnitPriority('month', 8);
-
     // PARSING
 
-    addRegexToken('M', match1to2);
+    addRegexToken('M', match1to2, match1to2NoLeadingZero);
     addRegexToken('MM', match1to2, match2);
     addRegexToken('MMM', function (isStrict, locale) {
         return locale.monthsShortRegex(isStrict);
@@ -66582,8 +66772,6 @@ exports.Zone = Zone;
     // MOMENTS
 
     function setMonth(mom, value) {
-        var dayOfMonth;
-
         if (!mom.isValid()) {
             // No op
             return mom;
@@ -66601,8 +66789,13 @@ exports.Zone = Zone;
             }
         }
 
-        dayOfMonth = Math.min(mom.date(), daysInMonth(mom.year(), value));
-        mom._d['set' + (mom._isUTC ? 'UTC' : '') + 'Month'](value, dayOfMonth);
+        var month = value,
+            date = mom.date();
+
+        date = date < 29 ? date : Math.min(date, daysInMonth(mom.year(), month));
+        void (mom._isUTC
+            ? mom._d.setUTCMonth(month, date)
+            : mom._d.setMonth(month, date));
         return mom;
     }
 
@@ -66669,27 +66862,24 @@ exports.Zone = Zone;
             longPieces = [],
             mixedPieces = [],
             i,
-            mom;
+            mom,
+            shortP,
+            longP;
         for (i = 0; i < 12; i++) {
             // make the regex if we don't have it already
             mom = createUTC([2000, i]);
-            shortPieces.push(this.monthsShort(mom, ''));
-            longPieces.push(this.months(mom, ''));
-            mixedPieces.push(this.months(mom, ''));
-            mixedPieces.push(this.monthsShort(mom, ''));
+            shortP = regexEscape(this.monthsShort(mom, ''));
+            longP = regexEscape(this.months(mom, ''));
+            shortPieces.push(shortP);
+            longPieces.push(longP);
+            mixedPieces.push(longP);
+            mixedPieces.push(shortP);
         }
         // Sorting makes sure if one month (or abbr) is a prefix of another it
         // will match the longer piece.
         shortPieces.sort(cmpLenRev);
         longPieces.sort(cmpLenRev);
         mixedPieces.sort(cmpLenRev);
-        for (i = 0; i < 12; i++) {
-            shortPieces[i] = regexEscape(shortPieces[i]);
-            longPieces[i] = regexEscape(longPieces[i]);
-        }
-        for (i = 0; i < 24; i++) {
-            mixedPieces[i] = regexEscape(mixedPieces[i]);
-        }
 
         this._monthsRegex = new RegExp('^(' + mixedPieces.join('|') + ')', 'i');
         this._monthsShortRegex = this._monthsRegex;
@@ -66701,69 +66891,6 @@ exports.Zone = Zone;
             '^(' + shortPieces.join('|') + ')',
             'i'
         );
-    }
-
-    // FORMATTING
-
-    addFormatToken('Y', 0, 0, function () {
-        var y = this.year();
-        return y <= 9999 ? zeroFill(y, 4) : '+' + y;
-    });
-
-    addFormatToken(0, ['YY', 2], 0, function () {
-        return this.year() % 100;
-    });
-
-    addFormatToken(0, ['YYYY', 4], 0, 'year');
-    addFormatToken(0, ['YYYYY', 5], 0, 'year');
-    addFormatToken(0, ['YYYYYY', 6, true], 0, 'year');
-
-    // ALIASES
-
-    addUnitAlias('year', 'y');
-
-    // PRIORITIES
-
-    addUnitPriority('year', 1);
-
-    // PARSING
-
-    addRegexToken('Y', matchSigned);
-    addRegexToken('YY', match1to2, match2);
-    addRegexToken('YYYY', match1to4, match4);
-    addRegexToken('YYYYY', match1to6, match6);
-    addRegexToken('YYYYYY', match1to6, match6);
-
-    addParseToken(['YYYYY', 'YYYYYY'], YEAR);
-    addParseToken('YYYY', function (input, array) {
-        array[YEAR] =
-            input.length === 2 ? hooks.parseTwoDigitYear(input) : toInt(input);
-    });
-    addParseToken('YY', function (input, array) {
-        array[YEAR] = hooks.parseTwoDigitYear(input);
-    });
-    addParseToken('Y', function (input, array) {
-        array[YEAR] = parseInt(input, 10);
-    });
-
-    // HELPERS
-
-    function daysInYear(year) {
-        return isLeapYear(year) ? 366 : 365;
-    }
-
-    // HOOKS
-
-    hooks.parseTwoDigitYear = function (input) {
-        return toInt(input) + (toInt(input) > 68 ? 1900 : 2000);
-    };
-
-    // MOMENTS
-
-    var getSetYear = makeGetSet('FullYear', true);
-
-    function getIsLeapYear() {
-        return isLeapYear(this.year());
     }
 
     function createDate(y, m, d, h, M, s, ms) {
@@ -66871,21 +66998,11 @@ exports.Zone = Zone;
     addFormatToken('w', ['ww', 2], 'wo', 'week');
     addFormatToken('W', ['WW', 2], 'Wo', 'isoWeek');
 
-    // ALIASES
-
-    addUnitAlias('week', 'w');
-    addUnitAlias('isoWeek', 'W');
-
-    // PRIORITIES
-
-    addUnitPriority('week', 5);
-    addUnitPriority('isoWeek', 5);
-
     // PARSING
 
-    addRegexToken('w', match1to2);
+    addRegexToken('w', match1to2, match1to2NoLeadingZero);
     addRegexToken('ww', match1to2, match2);
-    addRegexToken('W', match1to2);
+    addRegexToken('W', match1to2, match1to2NoLeadingZero);
     addRegexToken('WW', match1to2, match2);
 
     addWeekParseToken(
@@ -66946,17 +67063,6 @@ exports.Zone = Zone;
 
     addFormatToken('e', 0, 0, 'weekday');
     addFormatToken('E', 0, 0, 'isoWeekday');
-
-    // ALIASES
-
-    addUnitAlias('day', 'd');
-    addUnitAlias('weekday', 'e');
-    addUnitAlias('isoWeekday', 'E');
-
-    // PRIORITY
-    addUnitPriority('day', 11);
-    addUnitPriority('weekday', 11);
-    addUnitPriority('isoWeekday', 11);
 
     // PARSING
 
@@ -67037,24 +67143,24 @@ exports.Zone = Zone;
         return m === true
             ? shiftWeekdays(weekdays, this._week.dow)
             : m
-            ? weekdays[m.day()]
-            : weekdays;
+              ? weekdays[m.day()]
+              : weekdays;
     }
 
     function localeWeekdaysShort(m) {
         return m === true
             ? shiftWeekdays(this._weekdaysShort, this._week.dow)
             : m
-            ? this._weekdaysShort[m.day()]
-            : this._weekdaysShort;
+              ? this._weekdaysShort[m.day()]
+              : this._weekdaysShort;
     }
 
     function localeWeekdaysMin(m) {
         return m === true
             ? shiftWeekdays(this._weekdaysMin, this._week.dow)
             : m
-            ? this._weekdaysMin[m.day()]
-            : this._weekdaysMin;
+              ? this._weekdaysMin[m.day()]
+              : this._weekdaysMin;
     }
 
     function handleStrictParse$1(weekdayName, format, strict) {
@@ -67203,7 +67309,8 @@ exports.Zone = Zone;
         if (!this.isValid()) {
             return input != null ? this : NaN;
         }
-        var day = this._isUTC ? this._d.getUTCDay() : this._d.getDay();
+
+        var day = get(this, 'Day');
         if (input != null) {
             input = parseWeekday(input, this.localeData());
             return this.add(input - day, 'd');
@@ -67402,13 +67509,6 @@ exports.Zone = Zone;
     meridiem('a', true);
     meridiem('A', false);
 
-    // ALIASES
-
-    addUnitAlias('hour', 'h');
-
-    // PRIORITY
-    addUnitPriority('hour', 13);
-
     // PARSING
 
     function matchMeridiem(isStrict, locale) {
@@ -67417,9 +67517,9 @@ exports.Zone = Zone;
 
     addRegexToken('a', matchMeridiem);
     addRegexToken('A', matchMeridiem);
-    addRegexToken('H', match1to2);
-    addRegexToken('h', match1to2);
-    addRegexToken('k', match1to2);
+    addRegexToken('H', match1to2, match1to2HasZero);
+    addRegexToken('h', match1to2, match1to2NoLeadingZero);
+    addRegexToken('k', match1to2, match1to2NoLeadingZero);
     addRegexToken('HH', match1to2, match2);
     addRegexToken('hh', match1to2, match2);
     addRegexToken('kk', match1to2, match2);
@@ -67569,7 +67669,8 @@ exports.Zone = Zone;
 
     function isLocaleNameSane(name) {
         // Prevent names that look like filesystem paths, i.e contain '/' or '\'
-        return name.match('^[^/\\\\]*$') != null;
+        // Ensure name is available and function returns boolean
+        return !!(name && name.match('^[^/\\\\]*$'));
     }
 
     function loadLocale(name) {
@@ -67761,21 +67862,21 @@ exports.Zone = Zone;
                 a[MONTH] < 0 || a[MONTH] > 11
                     ? MONTH
                     : a[DATE] < 1 || a[DATE] > daysInMonth(a[YEAR], a[MONTH])
-                    ? DATE
-                    : a[HOUR] < 0 ||
-                      a[HOUR] > 24 ||
-                      (a[HOUR] === 24 &&
-                          (a[MINUTE] !== 0 ||
-                              a[SECOND] !== 0 ||
-                              a[MILLISECOND] !== 0))
-                    ? HOUR
-                    : a[MINUTE] < 0 || a[MINUTE] > 59
-                    ? MINUTE
-                    : a[SECOND] < 0 || a[SECOND] > 59
-                    ? SECOND
-                    : a[MILLISECOND] < 0 || a[MILLISECOND] > 999
-                    ? MILLISECOND
-                    : -1;
+                      ? DATE
+                      : a[HOUR] < 0 ||
+                          a[HOUR] > 24 ||
+                          (a[HOUR] === 24 &&
+                              (a[MINUTE] !== 0 ||
+                                  a[SECOND] !== 0 ||
+                                  a[MILLISECOND] !== 0))
+                        ? HOUR
+                        : a[MINUTE] < 0 || a[MINUTE] > 59
+                          ? MINUTE
+                          : a[SECOND] < 0 || a[SECOND] > 59
+                            ? SECOND
+                            : a[MILLISECOND] < 0 || a[MILLISECOND] > 999
+                              ? MILLISECOND
+                              : -1;
 
             if (
                 getParsingFlags(m)._overflowDayOfYear &&
@@ -69216,16 +69317,16 @@ exports.Zone = Zone;
         return diff < -6
             ? 'sameElse'
             : diff < -1
-            ? 'lastWeek'
-            : diff < 0
-            ? 'lastDay'
-            : diff < 1
-            ? 'sameDay'
-            : diff < 2
-            ? 'nextDay'
-            : diff < 7
-            ? 'nextWeek'
-            : 'sameElse';
+              ? 'lastWeek'
+              : diff < 0
+                ? 'lastDay'
+                : diff < 1
+                  ? 'sameDay'
+                  : diff < 2
+                    ? 'nextDay'
+                    : diff < 7
+                      ? 'nextWeek'
+                      : 'sameElse';
     }
 
     function calendar$1(time, formats) {
@@ -70033,16 +70134,22 @@ exports.Zone = Zone;
             mixedPieces = [],
             i,
             l,
+            erasName,
+            erasAbbr,
+            erasNarrow,
             eras = this.eras();
 
         for (i = 0, l = eras.length; i < l; ++i) {
-            namePieces.push(regexEscape(eras[i].name));
-            abbrPieces.push(regexEscape(eras[i].abbr));
-            narrowPieces.push(regexEscape(eras[i].narrow));
+            erasName = regexEscape(eras[i].name);
+            erasAbbr = regexEscape(eras[i].abbr);
+            erasNarrow = regexEscape(eras[i].narrow);
 
-            mixedPieces.push(regexEscape(eras[i].name));
-            mixedPieces.push(regexEscape(eras[i].abbr));
-            mixedPieces.push(regexEscape(eras[i].narrow));
+            namePieces.push(erasName);
+            abbrPieces.push(erasAbbr);
+            narrowPieces.push(erasNarrow);
+            mixedPieces.push(erasName);
+            mixedPieces.push(erasAbbr);
+            mixedPieces.push(erasNarrow);
         }
 
         this._erasRegex = new RegExp('^(' + mixedPieces.join('|') + ')', 'i');
@@ -70075,14 +70182,6 @@ exports.Zone = Zone;
 
     // ALIASES
 
-    addUnitAlias('weekYear', 'gg');
-    addUnitAlias('isoWeekYear', 'GG');
-
-    // PRIORITY
-
-    addUnitPriority('weekYear', 1);
-    addUnitPriority('isoWeekYear', 1);
-
     // PARSING
 
     addRegexToken('G', matchSigned);
@@ -70112,7 +70211,7 @@ exports.Zone = Zone;
             this,
             input,
             this.week(),
-            this.weekday(),
+            this.weekday() + this.localeData()._week.dow,
             this.localeData()._week.dow,
             this.localeData()._week.doy
         );
@@ -70174,14 +70273,6 @@ exports.Zone = Zone;
 
     addFormatToken('Q', 0, 'Qo', 'quarter');
 
-    // ALIASES
-
-    addUnitAlias('quarter', 'Q');
-
-    // PRIORITY
-
-    addUnitPriority('quarter', 7);
-
     // PARSING
 
     addRegexToken('Q', match1);
@@ -70201,16 +70292,9 @@ exports.Zone = Zone;
 
     addFormatToken('D', ['DD', 2], 'Do', 'date');
 
-    // ALIASES
-
-    addUnitAlias('date', 'D');
-
-    // PRIORITY
-    addUnitPriority('date', 9);
-
     // PARSING
 
-    addRegexToken('D', match1to2);
+    addRegexToken('D', match1to2, match1to2NoLeadingZero);
     addRegexToken('DD', match1to2, match2);
     addRegexToken('Do', function (isStrict, locale) {
         // TODO: Remove "ordinalParse" fallback in next major release.
@@ -70231,13 +70315,6 @@ exports.Zone = Zone;
     // FORMATTING
 
     addFormatToken('DDD', ['DDDD', 3], 'DDDo', 'dayOfYear');
-
-    // ALIASES
-
-    addUnitAlias('dayOfYear', 'DDD');
-
-    // PRIORITY
-    addUnitPriority('dayOfYear', 4);
 
     // PARSING
 
@@ -70263,17 +70340,9 @@ exports.Zone = Zone;
 
     addFormatToken('m', ['mm', 2], 0, 'minute');
 
-    // ALIASES
-
-    addUnitAlias('minute', 'm');
-
-    // PRIORITY
-
-    addUnitPriority('minute', 14);
-
     // PARSING
 
-    addRegexToken('m', match1to2);
+    addRegexToken('m', match1to2, match1to2HasZero);
     addRegexToken('mm', match1to2, match2);
     addParseToken(['m', 'mm'], MINUTE);
 
@@ -70285,17 +70354,9 @@ exports.Zone = Zone;
 
     addFormatToken('s', ['ss', 2], 0, 'second');
 
-    // ALIASES
-
-    addUnitAlias('second', 's');
-
-    // PRIORITY
-
-    addUnitPriority('second', 15);
-
     // PARSING
 
-    addRegexToken('s', match1to2);
+    addRegexToken('s', match1to2, match1to2HasZero);
     addRegexToken('ss', match1to2, match2);
     addParseToken(['s', 'ss'], SECOND);
 
@@ -70332,14 +70393,6 @@ exports.Zone = Zone;
     addFormatToken(0, ['SSSSSSSSS', 9], 0, function () {
         return this.millisecond() * 1000000;
     });
-
-    // ALIASES
-
-    addUnitAlias('millisecond', 'ms');
-
-    // PRIORITY
-
-    addUnitPriority('millisecond', 16);
 
     // PARSING
 
@@ -70648,12 +70701,12 @@ exports.Zone = Zone;
                     toInt((number % 100) / 10) === 1
                         ? 'th'
                         : b === 1
-                        ? 'st'
-                        : b === 2
-                        ? 'nd'
-                        : b === 3
-                        ? 'rd'
-                        : 'th';
+                          ? 'st'
+                          : b === 2
+                            ? 'nd'
+                            : b === 3
+                              ? 'rd'
+                              : 'th';
             return number + output;
         },
     });
@@ -70826,19 +70879,6 @@ exports.Zone = Zone;
         }
     }
 
-    // TODO: Use this.as('ms')?
-    function valueOf$1() {
-        if (!this.isValid()) {
-            return NaN;
-        }
-        return (
-            this._milliseconds +
-            this._days * 864e5 +
-            (this._months % 12) * 2592e6 +
-            toInt(this._months / 12) * 31536e6
-        );
-    }
-
     function makeAs(alias) {
         return function () {
             return this.as(alias);
@@ -70853,7 +70893,8 @@ exports.Zone = Zone;
         asWeeks = makeAs('w'),
         asMonths = makeAs('M'),
         asQuarters = makeAs('Q'),
-        asYears = makeAs('y');
+        asYears = makeAs('y'),
+        valueOf$1 = asMilliseconds;
 
     function clone$1() {
         return createDuration(this);
@@ -71122,7 +71163,7 @@ exports.Zone = Zone;
 
     //! moment.js
 
-    hooks.version = '2.29.4';
+    hooks.version = '2.30.1';
 
     setHookCallback(createLocal);
 
@@ -71171,7 +71212,7 @@ exports.Zone = Zone;
 
 })));
 
-},{}],219:[function(require,module,exports){
+},{}],227:[function(require,module,exports){
 /**
  * Export lib/mongoose
  *
@@ -71181,7 +71222,7 @@ exports.Zone = Zone;
 
 module.exports = require('./lib/browser');
 
-},{"./lib/browser":220}],220:[function(require,module,exports){
+},{"./lib/browser":228}],228:[function(require,module,exports){
 (function (Buffer){(function (){
 /* eslint-env browser */
 
@@ -71343,7 +71384,7 @@ if (typeof window !== 'undefined') {
 }
 
 }).call(this)}).call(this,require("buffer").Buffer)
-},{"./document_provider.js":230,"./driver":231,"./drivers/browser":235,"./error/index":239,"./promise_provider":309,"./schema":311,"./schematype.js":332,"./types":340,"./utils.js":344,"./virtualtype":345,"buffer":49}],221:[function(require,module,exports){
+},{"./document_provider.js":238,"./driver":239,"./drivers/browser":243,"./error/index":247,"./promise_provider":317,"./schema":319,"./schematype.js":340,"./types":348,"./utils.js":352,"./virtualtype":353,"buffer":49}],229:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -71445,7 +71486,7 @@ Document.$emitter = new EventEmitter();
 Document.ValidationError = ValidationError;
 module.exports = exports = Document;
 
-},{"./document":229,"./error/index":239,"./helpers/isObject":271,"./helpers/model/applyHooks":273,"./schema":311,"./types/objectid":342,"events":194}],222:[function(require,module,exports){
+},{"./document":237,"./error/index":247,"./helpers/isObject":279,"./helpers/model/applyHooks":281,"./schema":319,"./types/objectid":350,"events":202}],230:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -71811,7 +71852,7 @@ function _cast(val, numbertype, context) {
     }
   }
 }
-},{"./error/cast":237,"./error/strict":249,"./helpers/discriminator/getSchemaDiscriminatorByValue":260,"./helpers/get":265,"./helpers/getConstructorName":266,"./helpers/isMongooseObject":270,"./helpers/isObject":271,"./helpers/query/isOperator":280,"./schema/index":319,"./schema/operators/text":328,"util":370}],223:[function(require,module,exports){
+},{"./error/cast":245,"./error/strict":257,"./helpers/discriminator/getSchemaDiscriminatorByValue":268,"./helpers/get":273,"./helpers/getConstructorName":274,"./helpers/isMongooseObject":278,"./helpers/isObject":279,"./helpers/query/isOperator":288,"./schema/index":327,"./schema/operators/text":336,"util":383}],231:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../error/cast');
@@ -71845,7 +71886,7 @@ module.exports = function castBoolean(value, path) {
 module.exports.convertToTrue = new Set([true, 'true', 1, '1', 'yes']);
 module.exports.convertToFalse = new Set([false, 'false', 0, '0', 'no']);
 
-},{"../error/cast":237}],224:[function(require,module,exports){
+},{"../error/cast":245}],232:[function(require,module,exports){
 'use strict';
 
 const assert = require('assert');
@@ -71887,7 +71928,7 @@ module.exports = function castDate(value) {
 
   assert.ok(false);
 };
-},{"assert":22}],225:[function(require,module,exports){
+},{"assert":22}],233:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -71926,7 +71967,7 @@ module.exports = function castDecimal128(value) {
   assert.ok(false);
 };
 }).call(this)}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":209,"../types/decimal128":337,"assert":22}],226:[function(require,module,exports){
+},{"../../../is-buffer/index.js":217,"../types/decimal128":345,"assert":22}],234:[function(require,module,exports){
 'use strict';
 
 const assert = require('assert');
@@ -71971,7 +72012,7 @@ module.exports = function castNumber(val) {
   assert.ok(false);
 };
 
-},{"assert":22}],227:[function(require,module,exports){
+},{"assert":22}],235:[function(require,module,exports){
 'use strict';
 
 const ObjectId = require('../driver').get().ObjectId;
@@ -72001,7 +72042,7 @@ module.exports = function castObjectId(value) {
 
   assert.ok(false);
 };
-},{"../driver":231,"assert":22}],228:[function(require,module,exports){
+},{"../driver":239,"assert":22}],236:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../error/cast');
@@ -72040,7 +72081,7 @@ module.exports = function castString(value, path) {
   throw new CastError('string', value, path);
 };
 
-},{"../error/cast":237}],229:[function(require,module,exports){
+},{"../error/cast":245}],237:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -73113,6 +73154,8 @@ Document.prototype.$set = function $set(path, val, type, options) {
           } else {
             throw new StrictModeError(key);
           }
+        } else if (pathtype === 'nested' && path[key] == null) {
+          this.$set(pathName, path[key], constructing, options);
         }
       } else if (path[key] !== void 0) {
         this.$set(prefix + key, path[key], constructing, options);
@@ -76342,7 +76385,7 @@ Document.ValidationError = ValidationError;
 module.exports = exports = Document;
 
 }).call(this)}).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":209,"./error/index":239,"./error/objectExpected":244,"./error/objectParameter":245,"./error/parallelValidate":248,"./error/strict":249,"./error/validation":250,"./error/validator":251,"./helpers/common":255,"./helpers/document/cleanModifiedSubpaths":261,"./helpers/document/compile":262,"./helpers/document/getEmbeddedDiscriminatorPath":263,"./helpers/document/handleSpreadDoc":264,"./helpers/get":265,"./helpers/immediate":268,"./helpers/isPromise":272,"./helpers/projection/isDefiningProjection":276,"./helpers/projection/isExclusive":277,"./helpers/promiseOrCallback":278,"./helpers/symbols":289,"./internal":293,"./options":294,"./plugins/idGetter":308,"./queryhelpers":310,"./schema":311,"./schema/mixed":321,"./schema/symbols":331,"./types/array":334,"./types/documentarray":338,"./types/embedded":339,"./utils":344,"./virtualtype":345,"events":194,"mpath":346,"util":370}],230:[function(require,module,exports){
+},{"../../is-buffer/index.js":217,"./error/index":247,"./error/objectExpected":252,"./error/objectParameter":253,"./error/parallelValidate":256,"./error/strict":257,"./error/validation":258,"./error/validator":259,"./helpers/common":263,"./helpers/document/cleanModifiedSubpaths":269,"./helpers/document/compile":270,"./helpers/document/getEmbeddedDiscriminatorPath":271,"./helpers/document/handleSpreadDoc":272,"./helpers/get":273,"./helpers/immediate":276,"./helpers/isPromise":280,"./helpers/projection/isDefiningProjection":284,"./helpers/projection/isExclusive":285,"./helpers/promiseOrCallback":286,"./helpers/symbols":297,"./internal":301,"./options":302,"./plugins/idGetter":316,"./queryhelpers":318,"./schema":319,"./schema/mixed":329,"./schema/symbols":339,"./types/array":342,"./types/documentarray":346,"./types/embedded":347,"./utils":352,"./virtualtype":353,"events":202,"mpath":354,"util":383}],238:[function(require,module,exports){
 'use strict';
 
 /* eslint-env browser */
@@ -76374,7 +76417,7 @@ module.exports.setBrowser = function(flag) {
   isBrowser = flag;
 };
 
-},{"./browserDocument.js":221,"./document.js":229}],231:[function(require,module,exports){
+},{"./browserDocument.js":229,"./document.js":237}],239:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76391,7 +76434,7 @@ module.exports.set = function(v) {
   driver = v;
 };
 
-},{}],232:[function(require,module,exports){
+},{}],240:[function(require,module,exports){
 /*!
  * ignore
  */
@@ -76400,7 +76443,7 @@ module.exports.set = function(v) {
 
 module.exports = function() {};
 
-},{}],233:[function(require,module,exports){
+},{}],241:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -76416,7 +76459,7 @@ const Binary = require('bson').Binary;
 
 module.exports = exports = Binary;
 
-},{"bson":30}],234:[function(require,module,exports){
+},{"bson":30}],242:[function(require,module,exports){
 /*!
  * ignore
  */
@@ -76425,7 +76468,7 @@ module.exports = exports = Binary;
 
 module.exports = require('bson').Decimal128;
 
-},{"bson":30}],235:[function(require,module,exports){
+},{"bson":30}],243:[function(require,module,exports){
 /*!
  * Module exports.
  */
@@ -76443,7 +76486,7 @@ exports.Decimal128 = require('./decimal128');
 exports.ObjectId = require('./objectid');
 exports.ReadPreference = require('./ReadPreference');
 
-},{"./ReadPreference":232,"./binary":233,"./decimal128":234,"./objectid":236}],236:[function(require,module,exports){
+},{"./ReadPreference":240,"./binary":241,"./decimal128":242,"./objectid":244}],244:[function(require,module,exports){
 
 /*!
  * [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) ObjectId
@@ -76473,7 +76516,7 @@ Object.defineProperty(ObjectId.prototype, '_id', {
 
 module.exports = exports = ObjectId;
 
-},{"bson":30}],237:[function(require,module,exports){
+},{"bson":30}],245:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76625,7 +76668,7 @@ function formatMessage(model, kind, stringValue, path, messageFormat, valueType)
 
 module.exports = CastError;
 
-},{"../helpers/get":265,"./mongooseError":242,"util":370}],238:[function(require,module,exports){
+},{"../helpers/get":273,"./mongooseError":250,"util":383}],246:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -76664,7 +76707,7 @@ Object.defineProperty(DivergentArrayError.prototype, 'name', {
 
 module.exports = DivergentArrayError;
 
-},{"./":239}],239:[function(require,module,exports){
+},{"./":247}],247:[function(require,module,exports){
 'use strict';
 
 /**
@@ -76871,7 +76914,7 @@ MongooseError.DivergentArrayError = require('./divergentArray');
 
 MongooseError.StrictModeError = require('./strict');
 
-},{"./cast":237,"./divergentArray":238,"./messages":240,"./missingSchema":241,"./mongooseError":242,"./notFound":243,"./overwriteModel":246,"./parallelSave":247,"./strict":249,"./validation":250,"./validator":251,"./version":252}],240:[function(require,module,exports){
+},{"./cast":245,"./divergentArray":246,"./messages":248,"./missingSchema":249,"./mongooseError":250,"./notFound":251,"./overwriteModel":254,"./parallelSave":255,"./strict":257,"./validation":258,"./validator":259,"./version":260}],248:[function(require,module,exports){
 
 /**
  * The default built-in validator error messages. These may be customized.
@@ -76920,7 +76963,7 @@ msg.String.match = 'Path `{PATH}` is invalid ({VALUE}).';
 msg.String.minlength = 'Path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).';
 msg.String.maxlength = 'Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length ({MAXLENGTH}).';
 
-},{}],241:[function(require,module,exports){
+},{}],249:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -76952,7 +76995,7 @@ Object.defineProperty(MissingSchemaError.prototype, 'name', {
 
 module.exports = MissingSchemaError;
 
-},{"./":239}],242:[function(require,module,exports){
+},{"./":247}],250:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -76967,7 +77010,7 @@ Object.defineProperty(MongooseError.prototype, 'name', {
 
 module.exports = MongooseError;
 
-},{}],243:[function(require,module,exports){
+},{}],251:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -77013,7 +77056,7 @@ Object.defineProperty(DocumentNotFoundError.prototype, 'name', {
 
 module.exports = DocumentNotFoundError;
 
-},{"./":239,"util":370}],244:[function(require,module,exports){
+},{"./":247,"util":383}],252:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -77045,7 +77088,7 @@ Object.defineProperty(ObjectExpectedError.prototype, 'name', {
 
 module.exports = ObjectExpectedError;
 
-},{"./":239}],245:[function(require,module,exports){
+},{"./":247}],253:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -77077,7 +77120,7 @@ Object.defineProperty(ObjectParameterError.prototype, 'name', {
 
 module.exports = ObjectParameterError;
 
-},{"./":239}],246:[function(require,module,exports){
+},{"./":247}],254:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -77108,7 +77151,7 @@ Object.defineProperty(OverwriteModelError.prototype, 'name', {
 
 module.exports = OverwriteModelError;
 
-},{"./":239}],247:[function(require,module,exports){
+},{"./":247}],255:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -77140,7 +77183,7 @@ Object.defineProperty(ParallelSaveError.prototype, 'name', {
 
 module.exports = ParallelSaveError;
 
-},{"./":239}],248:[function(require,module,exports){
+},{"./":247}],256:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -77172,7 +77215,7 @@ Object.defineProperty(ParallelValidateError.prototype, 'name', {
  */
 
 module.exports = ParallelValidateError;
-},{"./mongooseError":242}],249:[function(require,module,exports){
+},{"./mongooseError":250}],257:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -77207,7 +77250,7 @@ Object.defineProperty(StrictModeError.prototype, 'name', {
 
 module.exports = StrictModeError;
 
-},{"./":239}],250:[function(require,module,exports){
+},{"./":247}],258:[function(require,module,exports){
 /*!
  * Module requirements
  */
@@ -77321,7 +77364,7 @@ function _generateMessage(err) {
 
 module.exports = ValidationError;
 
-},{"../helpers/getConstructorName":266,"./mongooseError":242,"util":370}],251:[function(require,module,exports){
+},{"../helpers/getConstructorName":274,"./mongooseError":250,"util":383}],259:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -77417,7 +77460,7 @@ function formatMessage(msg, properties) {
 
 module.exports = ValidatorError;
 
-},{"./":239}],252:[function(require,module,exports){
+},{"./":247}],260:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -77455,7 +77498,7 @@ Object.defineProperty(VersionError.prototype, 'name', {
 
 module.exports = VersionError;
 
-},{"./":239}],253:[function(require,module,exports){
+},{"./":247}],261:[function(require,module,exports){
 'use strict';
 
 module.exports = arrayDepth;
@@ -77489,7 +77532,7 @@ function arrayDepth(arr) {
 
   return res;
 }
-},{}],254:[function(require,module,exports){
+},{}],262:[function(require,module,exports){
 'use strict';
 
 
@@ -77633,7 +77676,7 @@ function cloneArray(arr, options) {
 
   return ret;
 }
-},{"../types/decimal128":337,"../types/objectid":342,"../utils":344,"./getFunctionName":267,"./isBsonType":269,"./isMongooseObject":270,"./isObject":271,"./specialProperties":288,"./symbols":289,"regexp-clone":363}],255:[function(require,module,exports){
+},{"../types/decimal128":345,"../types/objectid":350,"../utils":352,"./getFunctionName":275,"./isBsonType":277,"./isMongooseObject":278,"./isObject":279,"./specialProperties":296,"./symbols":297,"regexp-clone":376}],263:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -77743,7 +77786,7 @@ function shouldFlatten(val) {
 }
 
 }).call(this)}).call(this,require("buffer").Buffer)
-},{"../driver":231,"../types/decimal128":337,"../types/objectid":342,"./isMongooseObject":270,"buffer":49}],256:[function(require,module,exports){
+},{"../driver":239,"../types/decimal128":345,"../types/objectid":350,"./isMongooseObject":278,"buffer":49}],264:[function(require,module,exports){
 'use strict';
 
 const ObjectId = require('../../types/objectid');
@@ -77760,7 +77803,7 @@ module.exports = function areDiscriminatorValuesEqual(a, b) {
   }
   return false;
 };
-},{"../../types/objectid":342}],257:[function(require,module,exports){
+},{"../../types/objectid":350}],265:[function(require,module,exports){
 'use strict';
 
 module.exports = function checkEmbeddedDiscriminatorKeyProjection(userProjection, path, schema, selected, addedPaths) {
@@ -77773,7 +77816,7 @@ module.exports = function checkEmbeddedDiscriminatorKeyProjection(userProjection
     selected.splice(selected.indexOf(_discriminatorKey), 1);
   }
 };
-},{}],258:[function(require,module,exports){
+},{}],266:[function(require,module,exports){
 'use strict';
 
 const getDiscriminatorByValue = require('./getDiscriminatorByValue');
@@ -77799,7 +77842,7 @@ module.exports = function getConstructor(Constructor, value) {
 
   return Constructor;
 };
-},{"./getDiscriminatorByValue":259}],259:[function(require,module,exports){
+},{"./getDiscriminatorByValue":267}],267:[function(require,module,exports){
 'use strict';
 
 const areDiscriminatorValuesEqual = require('./areDiscriminatorValuesEqual');
@@ -77827,7 +77870,7 @@ module.exports = function getDiscriminatorByValue(discriminators, value) {
   }
   return null;
 };
-},{"./areDiscriminatorValuesEqual":256}],260:[function(require,module,exports){
+},{"./areDiscriminatorValuesEqual":264}],268:[function(require,module,exports){
 'use strict';
 
 const areDiscriminatorValuesEqual = require('./areDiscriminatorValuesEqual');
@@ -77854,7 +77897,7 @@ module.exports = function getSchemaDiscriminatorByValue(schema, value) {
   }
   return null;
 };
-},{"./areDiscriminatorValuesEqual":256}],261:[function(require,module,exports){
+},{"./areDiscriminatorValuesEqual":264}],269:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -77884,7 +77927,7 @@ module.exports = function cleanModifiedSubpaths(doc, path, options) {
   return deleted;
 };
 
-},{}],262:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 'use strict';
 
 const documentSchemaSymbol = require('../../helpers/symbols').documentSchemaSymbol;
@@ -78097,7 +78140,7 @@ function getOwnPropertyDescriptors(object) {
   return result;
 }
 
-},{"../../document":229,"../../helpers/get":265,"../../helpers/symbols":289,"../../options":294,"../../utils":344}],263:[function(require,module,exports){
+},{"../../document":237,"../../helpers/get":273,"../../helpers/symbols":297,"../../options":302,"../../utils":352}],271:[function(require,module,exports){
 'use strict';
 
 const get = require('../get');
@@ -78142,7 +78185,7 @@ module.exports = function getEmbeddedDiscriminatorPath(doc, path, options) {
   return typeOnly ? type : schema;
 };
 
-},{"../get":265}],264:[function(require,module,exports){
+},{"../get":273}],272:[function(require,module,exports){
 'use strict';
 
 const utils = require('../../utils');
@@ -78160,7 +78203,7 @@ module.exports = function handleSpreadDoc(v) {
 
   return v;
 };
-},{"../../utils":344}],265:[function(require,module,exports){
+},{"../../utils":352}],273:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -78225,7 +78268,7 @@ function getProperty(obj, prop) {
   }
   return obj[prop];
 }
-},{}],266:[function(require,module,exports){
+},{}],274:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -78241,7 +78284,7 @@ module.exports = function getConstructorName(val) {
   }
   return val.constructor.name;
 };
-},{}],267:[function(require,module,exports){
+},{}],275:[function(require,module,exports){
 'use strict';
 
 module.exports = function(fn) {
@@ -78251,7 +78294,7 @@ module.exports = function(fn) {
   return (fn.toString().trim().match(/^function\s*([^\s(]+)/) || [])[1];
 };
 
-},{}],268:[function(require,module,exports){
+},{}],276:[function(require,module,exports){
 (function (process){(function (){
 /*!
  * Centralize this so we can more easily work around issues with people
@@ -78269,7 +78312,7 @@ module.exports = function immediate(cb) {
 };
 
 }).call(this)}).call(this,require('_process'))
-},{"_process":362}],269:[function(require,module,exports){
+},{"_process":375}],277:[function(require,module,exports){
 'use strict';
 
 const get = require('./get');
@@ -78284,7 +78327,7 @@ function isBsonType(obj, typename) {
 
 module.exports = isBsonType;
 
-},{"./get":265}],270:[function(require,module,exports){
+},{"./get":273}],278:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -78306,7 +78349,7 @@ module.exports = function(v) {
     v.isMongooseBuffer || // Buffer
     v.$isMongooseMap; // Map
 };
-},{}],271:[function(require,module,exports){
+},{}],279:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -78325,14 +78368,14 @@ module.exports = function(arg) {
   return Object.prototype.toString.call(arg) === '[object Object]';
 };
 }).call(this)}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":209}],272:[function(require,module,exports){
+},{"../../../is-buffer/index.js":217}],280:[function(require,module,exports){
 'use strict';
 function isPromise(val) {
   return !!val && (typeof val === 'object' || typeof val === 'function') && typeof val.then === 'function';
 }
 
 module.exports = isPromise;
-},{}],273:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 'use strict';
 
 const symbols = require('../../schema/symbols');
@@ -78471,7 +78514,7 @@ function applyHooks(model, schema, options) {
       createWrapper(method, originalMethod, null, customMethodOptions);
   }
 }
-},{"../../schema/symbols":331,"../promiseOrCallback":278}],274:[function(require,module,exports){
+},{"../../schema/symbols":339,"../promiseOrCallback":286}],282:[function(require,module,exports){
 'use strict';
 
 const Mixed = require('../../schema/mixed');
@@ -78678,7 +78721,7 @@ module.exports = function discriminator(model, name, schema, tiedValue, applyPlu
   return schema;
 };
 
-},{"../../schema/mixed":321,"../../utils":344,"../document/compile":262,"../get":265}],275:[function(require,module,exports){
+},{"../../schema/mixed":329,"../../utils":352,"../document/compile":270,"../get":273}],283:[function(require,module,exports){
 'use strict';
 
 const MongooseError = require('../../error/mongooseError');
@@ -78698,7 +78741,7 @@ function validateRef(ref, path) {
   throw new MongooseError('Invalid ref at path "' + path + '". Got ' +
     util.inspect(ref, { depth: 0 }));
 }
-},{"../../error/mongooseError":242,"util":370}],276:[function(require,module,exports){
+},{"../../error/mongooseError":250,"util":383}],284:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -78718,7 +78761,7 @@ module.exports = function isDefiningProjection(val) {
   return true;
 };
 
-},{}],277:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 'use strict';
 
 const isDefiningProjection = require('./isDefiningProjection');
@@ -78752,7 +78795,7 @@ module.exports = function isExclusive(projection) {
   return exclude;
 };
 
-},{"./isDefiningProjection":276}],278:[function(require,module,exports){
+},{"./isDefiningProjection":284}],286:[function(require,module,exports){
 'use strict';
 
 const PromiseProvider = require('../promise_provider');
@@ -78800,7 +78843,7 @@ module.exports = function promiseOrCallback(callback, fn, ee, Promise) {
   });
 };
 
-},{"../promise_provider":309,"./immediate":268}],279:[function(require,module,exports){
+},{"../promise_provider":317,"./immediate":276}],287:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -78894,7 +78937,7 @@ function _getContexts(hook) {
   }
   return ret;
 }
-},{}],280:[function(require,module,exports){
+},{}],288:[function(require,module,exports){
 'use strict';
 
 const specialKeys = new Set([
@@ -78906,7 +78949,7 @@ const specialKeys = new Set([
 module.exports = function isOperator(path) {
   return path.startsWith('$') && !specialKeys.has(path);
 };
-},{}],281:[function(require,module,exports){
+},{}],289:[function(require,module,exports){
 'use strict';
 
 module.exports = function addAutoId(schema) {
@@ -78914,7 +78957,7 @@ module.exports = function addAutoId(schema) {
   _obj._id[schema.options.typeKey] = 'ObjectId';
   schema.add(_obj);
 };
-},{}],282:[function(require,module,exports){
+},{}],290:[function(require,module,exports){
 'use strict';
 
 /**
@@ -78927,7 +78970,7 @@ module.exports = function cleanPositionalOperators(path) {
     replace(/\.\$(\[[^\]]*\])?(?=\.)/g, '.0').
     replace(/\.\$(\[[^\]]*\])?$/g, '.0');
 };
-},{}],283:[function(require,module,exports){
+},{}],291:[function(require,module,exports){
 'use strict';
 
 const get = require('../get');
@@ -79084,7 +79127,7 @@ module.exports = function getIndexes(schema) {
   }
 };
 
-},{"../get":265,"../isObject":271}],284:[function(require,module,exports){
+},{"../get":273,"../isObject":279}],292:[function(require,module,exports){
 'use strict';
 
 const addAutoId = require('./addAutoId');
@@ -79105,7 +79148,7 @@ module.exports = function handleIdOption(schema, options) {
 
   return schema;
 };
-},{"./addAutoId":281}],285:[function(require,module,exports){
+},{"./addAutoId":289}],293:[function(require,module,exports){
 'use strict';
 
 module.exports = handleTimestampOption;
@@ -79130,7 +79173,7 @@ function handleTimestampOption(arg, prop) {
   }
   return arg[prop];
 }
-},{}],286:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 'use strict';
 
 module.exports = function merge(s1, s2, skipConflictingPaths) {
@@ -79160,7 +79203,7 @@ module.exports = function merge(s1, s2, skipConflictingPaths) {
   s1.s.hooks.merge(s2.s.hooks, false);
 };
 
-},{}],287:[function(require,module,exports){
+},{}],295:[function(require,module,exports){
 'use strict';
 
 const StrictModeError = require('../../error/strict');
@@ -79207,11 +79250,11 @@ function createImmutableSetter(path, immutable) {
   };
 }
 
-},{"../../error/strict":249}],288:[function(require,module,exports){
+},{"../../error/strict":257}],296:[function(require,module,exports){
 'use strict';
 
 module.exports = new Set(['__proto__', 'constructor', 'prototype']);
-},{}],289:[function(require,module,exports){
+},{}],297:[function(require,module,exports){
 'use strict';
 
 exports.arrayAtomicsSymbol = Symbol('mongoose#Array#_atomics');
@@ -79231,7 +79274,7 @@ exports.schemaTypeSymbol = Symbol('mongoose#schemaType');
 exports.sessionNewDocuments = Symbol('mongoose:ClientSession#newDocuments');
 exports.scopeSymbol = Symbol('mongoose#Document#scope');
 exports.validatorErrorSymbol = Symbol('mongoose:validatorError');
-},{}],290:[function(require,module,exports){
+},{}],298:[function(require,module,exports){
 'use strict';
 
 const applyTimestampsToChildren = require('../update/applyTimestampsToChildren');
@@ -79343,7 +79386,7 @@ module.exports = function setupTimestamps(schema, timestamps) {
     next();
   }
 };
-},{"../../schema/symbols":331,"../get":265,"../schema/handleTimestampOption":285,"../update/applyTimestampsToChildren":291,"../update/applyTimestampsToUpdate":292}],291:[function(require,module,exports){
+},{"../../schema/symbols":339,"../get":273,"../schema/handleTimestampOption":293,"../update/applyTimestampsToChildren":299,"../update/applyTimestampsToUpdate":300}],299:[function(require,module,exports){
 'use strict';
 
 const cleanPositionalOperators = require('../schema/cleanPositionalOperators');
@@ -79529,7 +79572,7 @@ function applyTimestampsToUpdateKey(schema, key, update, now) {
     }
   }
 }
-},{"../schema/cleanPositionalOperators":282,"../schema/handleTimestampOption":285}],292:[function(require,module,exports){
+},{"../schema/cleanPositionalOperators":290,"../schema/handleTimestampOption":293}],300:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -79650,7 +79693,7 @@ function applyTimestampsToUpdate(now, createdAt, updatedAt, currentUpdate, optio
   return updates;
 }
 
-},{"../get":265}],293:[function(require,module,exports){
+},{"../get":273}],301:[function(require,module,exports){
 /*!
  * Dependencies
  */
@@ -79690,7 +79733,7 @@ function InternalCache() {
   this.fullPath = undefined;
 }
 
-},{"./statemachine":333}],294:[function(require,module,exports){
+},{"./statemachine":341}],302:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -79707,7 +79750,7 @@ exports.internalToObjectOptions = {
   useProjection: false
 };
 
-},{}],295:[function(require,module,exports){
+},{}],303:[function(require,module,exports){
 'use strict';
 
 const clone = require('../helpers/clone');
@@ -79744,7 +79787,7 @@ class PopulateOptions {
  */
 
 module.exports = PopulateOptions;
-},{"../helpers/clone":254}],296:[function(require,module,exports){
+},{"../helpers/clone":262}],304:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -79804,7 +79847,7 @@ Object.defineProperty(SchemaArrayOptions.prototype, 'of', opts);
  */
 
 module.exports = SchemaArrayOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],297:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],305:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -79843,7 +79886,7 @@ Object.defineProperty(SchemaBufferOptions.prototype, 'subtype', opts);
  */
 
 module.exports = SchemaBufferOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],298:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],306:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -79908,7 +79951,7 @@ Object.defineProperty(SchemaDateOptions.prototype, 'expires', opts);
  */
 
 module.exports = SchemaDateOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],299:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],307:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -79977,7 +80020,7 @@ Object.defineProperty(SchemaDocumentArrayOptions.prototype, '_id', opts);
  */
 
 module.exports = SchemaDocumentArrayOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],300:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],308:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -80021,7 +80064,7 @@ const opts = require('./propertyOptions');
 Object.defineProperty(SchemaMapOptions.prototype, 'of', opts);
 
 module.exports = SchemaMapOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],301:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],309:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -80121,7 +80164,7 @@ Object.defineProperty(SchemaNumberOptions.prototype, 'populate', opts);
  */
 
 module.exports = SchemaNumberOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],302:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],310:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -80185,7 +80228,7 @@ Object.defineProperty(SchemaObjectIdOptions.prototype, 'populate', opts);
  */
 
 module.exports = SchemaObjectIdOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],303:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],311:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -80228,7 +80271,7 @@ const opts = require('./propertyOptions');
 Object.defineProperty(SchemaSingleNestedOptions.prototype, '_id', opts);
 
 module.exports = SchemaSingleNestedOptions;
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],304:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],312:[function(require,module,exports){
 'use strict';
 
 const SchemaTypeOptions = require('./SchemaTypeOptions');
@@ -80368,7 +80411,7 @@ Object.defineProperty(SchemaStringOptions.prototype, 'populate', opts);
 
 module.exports = SchemaStringOptions;
 
-},{"./SchemaTypeOptions":305,"./propertyOptions":307}],305:[function(require,module,exports){
+},{"./SchemaTypeOptions":313,"./propertyOptions":315}],313:[function(require,module,exports){
 'use strict';
 
 const clone = require('../helpers/clone');
@@ -80600,7 +80643,7 @@ Object.defineProperty(SchemaTypeOptions.prototype, 'text', opts);
 Object.defineProperty(SchemaTypeOptions.prototype, 'transform', opts);
 
 module.exports = SchemaTypeOptions;
-},{"../helpers/clone":254,"./propertyOptions":307}],306:[function(require,module,exports){
+},{"../helpers/clone":262,"./propertyOptions":315}],314:[function(require,module,exports){
 'use strict';
 
 const opts = require('./propertyOptions');
@@ -80765,7 +80808,7 @@ Object.defineProperty(VirtualOptions.prototype, 'limit', opts);
 Object.defineProperty(VirtualOptions.prototype, 'perDocumentLimit', opts);
 
 module.exports = VirtualOptions;
-},{"./propertyOptions":307}],307:[function(require,module,exports){
+},{"./propertyOptions":315}],315:[function(require,module,exports){
 'use strict';
 
 module.exports = Object.freeze({
@@ -80774,7 +80817,7 @@ module.exports = Object.freeze({
   writable: true,
   value: void 0
 });
-},{}],308:[function(require,module,exports){
+},{}],316:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -80804,7 +80847,7 @@ function idGetter() {
   return null;
 }
 
-},{}],309:[function(require,module,exports){
+},{}],317:[function(require,module,exports){
 (function (global){(function (){
 /*!
  * ignore
@@ -80857,7 +80900,7 @@ store.set(global.Promise);
 module.exports = store;
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"assert":22,"mquery":353}],310:[function(require,module,exports){
+},{"assert":22,"mquery":361}],318:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -81189,7 +81232,7 @@ exports.handleDeleteWriteOpResult = function handleDeleteWriteOpResult(callback)
   };
 };
 
-},{"./helpers/clone":254,"./helpers/discriminator/checkEmbeddedDiscriminatorKeyProjection":257,"./helpers/discriminator/getDiscriminatorByValue":259,"./helpers/get":265,"./helpers/projection/isDefiningProjection":276}],311:[function(require,module,exports){
+},{"./helpers/clone":262,"./helpers/discriminator/checkEmbeddedDiscriminatorKeyProjection":265,"./helpers/discriminator/getDiscriminatorByValue":267,"./helpers/get":273,"./helpers/projection/isDefiningProjection":284}],319:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -81216,6 +81259,8 @@ const setupTimestamps = require('./helpers/timestamps/setupTimestamps');
 const util = require('util');
 const utils = require('./utils');
 const validateRef = require('./helpers/populate/validateRef');
+
+const hasNumericSubpathRegex = /\.\d+(\.|$)/;
 
 let MongooseTypes;
 
@@ -81838,7 +81883,7 @@ Schema.prototype.path = function(path, obj) {
     }
 
     // subpaths?
-    return /\.\d+\.?.*$/.test(path)
+    return hasNumericSubpathRegex.test(path)
       ? getPositionalPath(this, path)
       : undefined;
   }
@@ -83395,7 +83440,7 @@ Schema.Types = MongooseTypes = require('./schema/index');
 exports.ObjectId = MongooseTypes.ObjectId;
 
 }).call(this)}).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":209,"./driver":231,"./error/mongooseError":242,"./helpers/get":265,"./helpers/getConstructorName":266,"./helpers/model/applyHooks":273,"./helpers/populate/validateRef":275,"./helpers/query/applyQueryMiddleware":279,"./helpers/schema/addAutoId":281,"./helpers/schema/getIndexes":283,"./helpers/schema/merge":286,"./helpers/symbols":289,"./helpers/timestamps/setupTimestamps":290,"./options/SchemaTypeOptions":305,"./options/VirtualOptions":306,"./schema/index":319,"./schematype":332,"./utils":344,"./virtualtype":345,"events":194,"kareem":215,"mpath":346,"util":370}],312:[function(require,module,exports){
+},{"../../is-buffer/index.js":217,"./driver":239,"./error/mongooseError":250,"./helpers/get":273,"./helpers/getConstructorName":274,"./helpers/model/applyHooks":281,"./helpers/populate/validateRef":283,"./helpers/query/applyQueryMiddleware":287,"./helpers/schema/addAutoId":289,"./helpers/schema/getIndexes":291,"./helpers/schema/merge":294,"./helpers/symbols":297,"./helpers/timestamps/setupTimestamps":298,"./options/SchemaTypeOptions":313,"./options/VirtualOptions":314,"./schema/index":327,"./schematype":340,"./utils":352,"./virtualtype":353,"events":202,"kareem":223,"mpath":354,"util":383}],320:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -83733,7 +83778,7 @@ SingleNestedPath.prototype.clone = function() {
   return schematype;
 };
 
-},{"../error/cast":237,"../error/objectExpected":244,"../helpers/discriminator/getConstructor":258,"../helpers/get":265,"../helpers/model/discriminator":274,"../helpers/schema/handleIdOption":284,"../options":294,"../options/SchemaSingleNestedOptions":303,"../schematype":332,"../types/subdocument":343,"./operators/exists":325,"./operators/geospatial":326,"./operators/helpers":327,"events":194}],313:[function(require,module,exports){
+},{"../error/cast":245,"../error/objectExpected":252,"../helpers/discriminator/getConstructor":266,"../helpers/get":273,"../helpers/model/discriminator":282,"../helpers/schema/handleIdOption":292,"../options":302,"../options/SchemaSingleNestedOptions":311,"../schematype":340,"../types/subdocument":351,"./operators/exists":333,"./operators/geospatial":334,"./operators/helpers":335,"events":202}],321:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -84386,7 +84431,7 @@ handle.$in = SchemaType.prototype.$conditionalHandlers.$in;
 
 module.exports = SchemaArray;
 
-},{"../cast":222,"../error/mongooseError":242,"../helpers/arrayDepth":253,"../helpers/discriminator/getDiscriminatorByValue":259,"../helpers/get":265,"../helpers/query/isOperator":280,"../options/SchemaArrayOptions":296,"../schematype":332,"../types":340,"../utils":344,"./index.js":319,"./mixed":321,"./operators/exists":325,"./operators/geospatial":326,"./operators/helpers":327,"./operators/type":329,"util":370}],314:[function(require,module,exports){
+},{"../cast":230,"../error/mongooseError":250,"../helpers/arrayDepth":261,"../helpers/discriminator/getDiscriminatorByValue":267,"../helpers/get":273,"../helpers/query/isOperator":288,"../options/SchemaArrayOptions":304,"../schematype":340,"../types":348,"../utils":352,"./index.js":327,"./mixed":329,"./operators/exists":333,"./operators/geospatial":334,"./operators/helpers":335,"./operators/type":337,"util":383}],322:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -84658,7 +84703,7 @@ SchemaBoolean.prototype._castNullish = function _castNullish(v) {
 
 module.exports = SchemaBoolean;
 
-},{"../cast/boolean":223,"../error/cast":237,"../schematype":332,"../utils":344}],315:[function(require,module,exports){
+},{"../cast/boolean":231,"../error/cast":245,"../schematype":340,"../utils":352}],323:[function(require,module,exports){
 (function (Buffer){(function (){
 /*!
  * Module dependencies.
@@ -84929,7 +84974,7 @@ SchemaBuffer.prototype.castForQuery = function($conditional, val) {
 module.exports = SchemaBuffer;
 
 }).call(this)}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":209,"../options/SchemaBufferOptions":297,"../schematype":332,"../types/buffer":335,"../utils":344,"./operators/bitwise":324}],316:[function(require,module,exports){
+},{"../../../is-buffer/index.js":217,"../options/SchemaBufferOptions":305,"../schematype":340,"../types/buffer":343,"../utils":352,"./operators/bitwise":332}],324:[function(require,module,exports){
 /*!
  * Module requirements.
  */
@@ -85334,7 +85379,7 @@ SchemaDate.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaDate;
 
-},{"../cast/date":224,"../error/index":239,"../helpers/getConstructorName":266,"../options/SchemaDateOptions":298,"../schematype":332,"../utils":344}],317:[function(require,module,exports){
+},{"../cast/date":232,"../error/index":247,"../helpers/getConstructorName":274,"../options/SchemaDateOptions":306,"../schematype":340,"../utils":352}],325:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -85546,7 +85591,7 @@ Decimal128.prototype.$conditionalHandlers =
 
 module.exports = Decimal128;
 
-},{"../cast/decimal128":225,"../schematype":332,"../types/decimal128":337,"../utils":344}],318:[function(require,module,exports){
+},{"../cast/decimal128":233,"../schematype":340,"../types/decimal128":345,"../utils":352}],326:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -86116,7 +86161,7 @@ DocumentArrayPath.set = SchemaType.set;
 
 module.exports = DocumentArrayPath;
 
-},{"../error/cast":237,"../error/validation":250,"../helpers/discriminator/getConstructor":258,"../helpers/get":265,"../helpers/model/discriminator":274,"../helpers/schema/handleIdOption":284,"../helpers/symbols":289,"../options/SchemaDocumentArrayOptions":299,"../schematype":332,"../types/documentarray":338,"../types/embedded":339,"../utils":344,"./array":313,"events":194,"util":370}],319:[function(require,module,exports){
+},{"../error/cast":245,"../error/validation":258,"../helpers/discriminator/getConstructor":266,"../helpers/get":273,"../helpers/model/discriminator":282,"../helpers/schema/handleIdOption":292,"../helpers/symbols":297,"../options/SchemaDocumentArrayOptions":307,"../schematype":340,"../types/documentarray":346,"../types/embedded":347,"../utils":352,"./array":321,"events":202,"util":383}],327:[function(require,module,exports){
 
 /*!
  * Module exports.
@@ -86155,7 +86200,7 @@ exports.Object = exports.Mixed;
 exports.Bool = exports.Boolean;
 exports.ObjectID = exports.ObjectId;
 
-},{"./SingleNestedPath":312,"./array":313,"./boolean":314,"./buffer":315,"./date":316,"./decimal128":317,"./documentarray":318,"./map":320,"./mixed":321,"./number":322,"./objectid":323,"./string":330}],320:[function(require,module,exports){
+},{"./SingleNestedPath":320,"./array":321,"./boolean":322,"./buffer":323,"./date":324,"./decimal128":325,"./documentarray":326,"./map":328,"./mixed":329,"./number":330,"./objectid":331,"./string":338}],328:[function(require,module,exports){
 (function (global){(function (){
 'use strict';
 
@@ -86235,7 +86280,7 @@ Map.defaultOptions = {};
 module.exports = Map;
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../options/SchemaMapOptions":300,"../schematype":332,"../types/map":341}],321:[function(require,module,exports){
+},{"../options/SchemaMapOptions":308,"../schematype":340,"../types/map":349}],329:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -86369,7 +86414,7 @@ Mixed.prototype.castForQuery = function($cond, val) {
 
 module.exports = Mixed;
 
-},{"../helpers/isObject":271,"../schematype":332,"../utils":344,"./symbols":331}],322:[function(require,module,exports){
+},{"../helpers/isObject":279,"../schematype":340,"../utils":352,"./symbols":339}],330:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -86804,7 +86849,7 @@ SchemaNumber.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaNumber;
 
-},{"../cast/number":226,"../error/index":239,"../options/SchemaNumberOptions":301,"../schematype":332,"../utils":344,"./operators/bitwise":324}],323:[function(require,module,exports){
+},{"../cast/number":234,"../error/index":247,"../options/SchemaNumberOptions":309,"../schematype":340,"../utils":352,"./operators/bitwise":332}],331:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -87104,7 +87149,7 @@ function resetId(v) {
 
 module.exports = ObjectId;
 
-},{"../cast/objectid":227,"../helpers/getConstructorName":266,"../options/SchemaObjectIdOptions":302,"../schematype":332,"../types/objectid":342,"../utils":344,"./../document":229}],324:[function(require,module,exports){
+},{"../cast/objectid":235,"../helpers/getConstructorName":274,"../options/SchemaObjectIdOptions":310,"../schematype":340,"../types/objectid":350,"../utils":352,"./../document":237}],332:[function(require,module,exports){
 (function (Buffer){(function (){
 /*!
  * Module requirements.
@@ -87146,7 +87191,7 @@ function _castNumber(path, num) {
 module.exports = handleBitwiseOperator;
 
 }).call(this)}).call(this,{"isBuffer":require("../../../../is-buffer/index.js")})
-},{"../../../../is-buffer/index.js":209,"../../error/cast":237}],325:[function(require,module,exports){
+},{"../../../../is-buffer/index.js":217,"../../error/cast":245}],333:[function(require,module,exports){
 'use strict';
 
 const castBoolean = require('../../cast/boolean');
@@ -87160,7 +87205,7 @@ module.exports = function(val) {
   return castBoolean(val, path);
 };
 
-},{"../../cast/boolean":223}],326:[function(require,module,exports){
+},{"../../cast/boolean":231}],334:[function(require,module,exports){
 /*!
  * Module requirements.
  */
@@ -87269,7 +87314,7 @@ function _castMinMaxDistance(self, val) {
   }
 }
 
-},{"../array":313,"./helpers":327}],327:[function(require,module,exports){
+},{"../array":321,"./helpers":335}],335:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -87303,7 +87348,7 @@ function castArraysOfNumbers(arr, self) {
   });
 }
 
-},{"../number":322}],328:[function(require,module,exports){
+},{"../number":330}],336:[function(require,module,exports){
 'use strict';
 
 const CastError = require('../../error/cast');
@@ -87344,7 +87389,7 @@ module.exports = function(val, path) {
   return val;
 };
 
-},{"../../cast/boolean":223,"../../cast/string":228,"../../error/cast":237}],329:[function(require,module,exports){
+},{"../../cast/boolean":231,"../../cast/string":236,"../../error/cast":245}],337:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -87366,7 +87411,7 @@ module.exports = function(val) {
   return val;
 };
 
-},{}],330:[function(require,module,exports){
+},{}],338:[function(require,module,exports){
 'use strict';
 
 /*!
@@ -88040,13 +88085,13 @@ SchemaString.prototype.castForQuery = function($conditional, val) {
 
 module.exports = SchemaString;
 
-},{"../cast/string":228,"../error/index":239,"../options/SchemaStringOptions":304,"../schematype":332,"../utils":344}],331:[function(require,module,exports){
+},{"../cast/string":236,"../error/index":247,"../options/SchemaStringOptions":312,"../schematype":340,"../utils":352}],339:[function(require,module,exports){
 'use strict';
 
 exports.schemaMixedSymbol = Symbol.for('mongoose:schema_mixed');
 
 exports.builtInMiddleware = Symbol.for('mongoose:built-in-middleware');
-},{}],332:[function(require,module,exports){
+},{}],340:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -89722,7 +89767,7 @@ exports.CastError = CastError;
 exports.ValidatorError = ValidatorError;
 
 }).call(this)}).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":209,"./error/index":239,"./helpers/get":265,"./helpers/immediate":268,"./helpers/schematype/handleImmutable":287,"./helpers/symbols":289,"./options/SchemaTypeOptions":305,"./schema/operators/exists":325,"./schema/operators/type":329,"./utils":344,"util":370}],333:[function(require,module,exports){
+},{"../../is-buffer/index.js":217,"./error/index":247,"./helpers/get":273,"./helpers/immediate":276,"./helpers/schematype/handleImmutable":295,"./helpers/symbols":297,"./options/SchemaTypeOptions":313,"./schema/operators/exists":333,"./schema/operators/type":337,"./utils":352,"util":383}],341:[function(require,module,exports){
 
 /*!
  * Module dependencies.
@@ -89904,7 +89949,7 @@ StateMachine.prototype.map = function map() {
   return this.map.apply(this, arguments);
 };
 
-},{"./utils":344}],334:[function(require,module,exports){
+},{"./utils":352}],342:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -89987,7 +90032,7 @@ function MongooseArray(values, path, doc, schematype) {
 
 module.exports = exports = MongooseArray;
 
-},{"../helpers/symbols":289,"./core_array":336}],335:[function(require,module,exports){
+},{"../helpers/symbols":297,"./core_array":344}],343:[function(require,module,exports){
 /*!
  * Module dependencies.
  */
@@ -90265,7 +90310,7 @@ MongooseBuffer.Binary = Binary;
 
 module.exports = MongooseBuffer;
 
-},{"../driver":231,"../utils":344,"safe-buffer":364}],336:[function(require,module,exports){
+},{"../driver":239,"../utils":352,"safe-buffer":377}],344:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -91239,7 +91284,7 @@ function _checkManualPopulation(arr, docs) {
 module.exports = CoreMongooseArray;
 
 }).call(this)}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":209,"../document":229,"../error/mongooseError":242,"../helpers/document/cleanModifiedSubpaths":261,"../helpers/get":265,"../helpers/symbols":289,"../options":294,"../utils":344,"./embedded":339,"./objectid":342,"util":370}],337:[function(require,module,exports){
+},{"../../../is-buffer/index.js":217,"../document":237,"../error/mongooseError":250,"../helpers/document/cleanModifiedSubpaths":269,"../helpers/get":273,"../helpers/symbols":297,"../options":302,"../utils":352,"./embedded":347,"./objectid":350,"util":383}],345:[function(require,module,exports){
 /**
  * ObjectId type constructor
  *
@@ -91254,7 +91299,7 @@ module.exports = CoreMongooseArray;
 
 module.exports = require('../driver').get().Decimal128;
 
-},{"../driver":231}],338:[function(require,module,exports){
+},{"../driver":239}],346:[function(require,module,exports){
 (function (Buffer){(function (){
 'use strict';
 
@@ -91706,7 +91751,7 @@ function MongooseDocumentArray(values, path, doc) {
 module.exports = MongooseDocumentArray;
 
 }).call(this)}).call(this,{"isBuffer":require("../../../is-buffer/index.js")})
-},{"../../../is-buffer/index.js":209,"../cast/objectid":227,"../document":229,"../helpers/discriminator/getDiscriminatorByValue":259,"../helpers/symbols":289,"../options":294,"../utils":344,"./core_array":336,"./objectid":342,"util":370}],339:[function(require,module,exports){
+},{"../../../is-buffer/index.js":217,"../cast/objectid":235,"../document":237,"../helpers/discriminator/getDiscriminatorByValue":267,"../helpers/symbols":297,"../options":302,"../utils":352,"./core_array":344,"./objectid":350,"util":383}],347:[function(require,module,exports){
 /* eslint no-func-assign: 1 */
 
 /*!
@@ -92168,7 +92213,7 @@ EmbeddedDocument.prototype.parentArray = function() {
 
 module.exports = EmbeddedDocument;
 
-},{"../document_provider":230,"../error/validation":250,"../helpers/get":265,"../helpers/immediate":268,"../helpers/promiseOrCallback":278,"../helpers/symbols":289,"../options":294,"events":194,"util":370}],340:[function(require,module,exports){
+},{"../document_provider":238,"../error/validation":258,"../helpers/get":273,"../helpers/immediate":276,"../helpers/promiseOrCallback":286,"../helpers/symbols":297,"../options":302,"events":202,"util":383}],348:[function(require,module,exports){
 
 /*!
  * Module exports.
@@ -92190,7 +92235,7 @@ exports.Map = require('./map');
 
 exports.Subdocument = require('./subdocument');
 
-},{"./array":334,"./buffer":335,"./decimal128":337,"./documentarray":338,"./embedded":339,"./map":341,"./objectid":342,"./subdocument":343}],341:[function(require,module,exports){
+},{"./array":342,"./buffer":343,"./decimal128":345,"./documentarray":346,"./embedded":347,"./map":349,"./objectid":350,"./subdocument":351}],349:[function(require,module,exports){
 'use strict';
 
 const Mixed = require('../schema/mixed');
@@ -92432,7 +92477,7 @@ function checkValidKey(key) {
 
 module.exports = MongooseMap;
 
-},{"../helpers/clone":254,"../helpers/document/handleSpreadDoc":264,"../helpers/get":265,"../helpers/getConstructorName":266,"../helpers/specialProperties":288,"../helpers/symbols":289,"../schema/mixed":321,"../utils":344,"./objectid":342,"util":370}],342:[function(require,module,exports){
+},{"../helpers/clone":262,"../helpers/document/handleSpreadDoc":272,"../helpers/get":273,"../helpers/getConstructorName":274,"../helpers/specialProperties":296,"../helpers/symbols":297,"../schema/mixed":329,"../utils":352,"./objectid":350,"util":383}],350:[function(require,module,exports){
 /**
  * ObjectId type constructor
  *
@@ -92464,7 +92509,7 @@ ObjectId.prototype[objectIdSymbol] = true;
 
 module.exports = ObjectId;
 
-},{"../driver":231,"../helpers/symbols":289}],343:[function(require,module,exports){
+},{"../driver":239,"../helpers/symbols":297}],351:[function(require,module,exports){
 'use strict';
 
 const Document = require('../document');
@@ -92767,7 +92812,7 @@ function registerRemoveListener(sub) {
   owner.on('remove', emitRemove);
 }
 
-},{"../document":229,"../helpers/immediate":268,"../helpers/promiseOrCallback":278,"../helpers/symbols":289,"../options":294}],344:[function(require,module,exports){
+},{"../document":237,"../helpers/immediate":276,"../helpers/promiseOrCallback":286,"../helpers/symbols":297,"../options":302}],352:[function(require,module,exports){
 (function (process){(function (){
 'use strict';
 
@@ -93712,7 +93757,7 @@ exports.nodeMajorVersion = function nodeMajorVersion() {
 };
 
 }).call(this)}).call(this,require('_process'))
-},{"./document":229,"./helpers/clone":254,"./helpers/getFunctionName":267,"./helpers/immediate":268,"./helpers/isBsonType":269,"./helpers/isMongooseObject":270,"./helpers/isObject":271,"./helpers/promiseOrCallback":278,"./helpers/schema/merge":286,"./helpers/specialProperties":288,"./options/PopulateOptions":295,"./types/decimal128":337,"./types/objectid":342,"_process":362,"mpath":346,"ms":360,"safe-buffer":364,"sliced":366}],345:[function(require,module,exports){
+},{"./document":237,"./helpers/clone":262,"./helpers/getFunctionName":275,"./helpers/immediate":276,"./helpers/isBsonType":277,"./helpers/isMongooseObject":278,"./helpers/isObject":279,"./helpers/promiseOrCallback":286,"./helpers/schema/merge":294,"./helpers/specialProperties":296,"./options/PopulateOptions":303,"./types/decimal128":345,"./types/objectid":350,"_process":375,"mpath":354,"ms":368,"safe-buffer":377,"sliced":379}],353:[function(require,module,exports){
 'use strict';
 
 const utils = require('./utils');
@@ -93890,12 +93935,12 @@ VirtualType.prototype.applySetters = function(value, doc) {
 
 module.exports = VirtualType;
 
-},{"./utils":344}],346:[function(require,module,exports){
+},{"./utils":352}],354:[function(require,module,exports){
 'use strict';
 
 module.exports = exports = require('./lib');
 
-},{"./lib":347}],347:[function(require,module,exports){
+},{"./lib":355}],355:[function(require,module,exports){
 /* eslint strict:off */
 /* eslint no-var: off */
 /* eslint no-redeclare: off */
@@ -94222,7 +94267,7 @@ function _setArray(obj, val, part, lookup, special, map) {
 function K(v) {
   return v;
 }
-},{"./stringToParts":348}],348:[function(require,module,exports){
+},{"./stringToParts":356}],356:[function(require,module,exports){
 'use strict';
 
 module.exports = function stringToParts(str) {
@@ -94271,7 +94316,7 @@ module.exports = function stringToParts(str) {
 
   return result;
 };
-},{}],349:[function(require,module,exports){
+},{}],357:[function(require,module,exports){
 'use strict';
 
 /**
@@ -94319,7 +94364,7 @@ function notImplemented(method) {
   };
 }
 
-},{}],350:[function(require,module,exports){
+},{}],358:[function(require,module,exports){
 'use strict';
 
 var env = require('../env');
@@ -94334,7 +94379,7 @@ module.exports =
       require('./collection');
 
 
-},{"../env":352,"./collection":349,"./node":351}],351:[function(require,module,exports){
+},{"../env":360,"./collection":357,"./node":359}],359:[function(require,module,exports){
 'use strict';
 
 /**
@@ -94487,7 +94532,7 @@ NodeCollection.prototype.findCursor = function(match, findOptions) {
 
 module.exports = exports = NodeCollection;
 
-},{"../utils":355,"./collection":349}],352:[function(require,module,exports){
+},{"../utils":363,"./collection":357}],360:[function(require,module,exports){
 (function (process,global,Buffer){(function (){
 'use strict';
 
@@ -94513,7 +94558,7 @@ exports.type = exports.isNode ? 'node'
       : 'unknown';
 
 }).call(this)}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"_process":362,"buffer":49}],353:[function(require,module,exports){
+},{"_process":375,"buffer":49}],361:[function(require,module,exports){
 'use strict';
 
 /**
@@ -97767,7 +97812,7 @@ module.exports = exports = Query;
 // TODO
 // test utils
 
-},{"./collection":350,"./collection/collection":349,"./env":352,"./permissions":354,"./utils":355,"assert":22,"bluebird":28,"debug":356,"sliced":366,"util":370}],354:[function(require,module,exports){
+},{"./collection":358,"./collection/collection":357,"./env":360,"./permissions":362,"./utils":363,"assert":22,"bluebird":28,"debug":364,"sliced":379,"util":383}],362:[function(require,module,exports){
 'use strict';
 
 var denied = exports;
@@ -97857,7 +97902,7 @@ denied.count.maxScan =
 denied.count.snapshot =
 denied.count.tailable = true;
 
-},{}],355:[function(require,module,exports){
+},{}],363:[function(require,module,exports){
 (function (process,setImmediate){(function (){
 'use strict';
 
@@ -98224,7 +98269,7 @@ exports.isArgumentsObject = function(v) {
 };
 
 }).call(this)}).call(this,require('_process'),require("timers").setImmediate)
-},{"_process":362,"regexp-clone":363,"safe-buffer":359,"timers":367}],356:[function(require,module,exports){
+},{"_process":375,"regexp-clone":376,"safe-buffer":367,"timers":380}],364:[function(require,module,exports){
 (function (process){(function (){
 /**
  * This is the web browser implementation of `debug()`.
@@ -98423,7 +98468,7 @@ function localstorage() {
 }
 
 }).call(this)}).call(this,require('_process'))
-},{"./debug":357,"_process":362}],357:[function(require,module,exports){
+},{"./debug":365,"_process":375}],365:[function(require,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -98650,7 +98695,7 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":358}],358:[function(require,module,exports){
+},{"ms":366}],366:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -98804,7 +98849,7 @@ function plural(ms, n, name) {
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
 
-},{}],359:[function(require,module,exports){
+},{}],367:[function(require,module,exports){
 /* eslint-disable node/no-deprecated-api */
 var buffer = require('buffer')
 var Buffer = buffer.Buffer
@@ -98868,7 +98913,7 @@ SafeBuffer.allocUnsafeSlow = function (size) {
   return buffer.SlowBuffer(size)
 }
 
-},{"buffer":49}],360:[function(require,module,exports){
+},{"buffer":49}],368:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -99032,99 +99077,307 @@ function plural(ms, msAbs, n, name) {
   return Math.round(ms / n) + ' ' + name + (isPlural ? 's' : '');
 }
 
-},{}],361:[function(require,module,exports){
-/*
-object-assign
-(c) Sindre Sorhus
-@license MIT
-*/
-
+},{}],369:[function(require,module,exports){
 'use strict';
-/* eslint-disable no-unused-vars */
-var getOwnPropertySymbols = Object.getOwnPropertySymbols;
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 
-function toObject(val) {
-	if (val === null || val === undefined) {
-		throw new TypeError('Object.assign cannot be called with null or undefined');
-	}
-
-	return Object(val);
-}
-
-function shouldUseNative() {
-	try {
-		if (!Object.assign) {
-			return false;
+var keysShim;
+if (!Object.keys) {
+	// modified from https://github.com/es-shims/es5-shim
+	var has = Object.prototype.hasOwnProperty;
+	var toStr = Object.prototype.toString;
+	var isArgs = require('./isArguments'); // eslint-disable-line global-require
+	var isEnumerable = Object.prototype.propertyIsEnumerable;
+	var hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
+	var hasProtoEnumBug = isEnumerable.call(function () {}, 'prototype');
+	var dontEnums = [
+		'toString',
+		'toLocaleString',
+		'valueOf',
+		'hasOwnProperty',
+		'isPrototypeOf',
+		'propertyIsEnumerable',
+		'constructor'
+	];
+	var equalsConstructorPrototype = function (o) {
+		var ctor = o.constructor;
+		return ctor && ctor.prototype === o;
+	};
+	var excludedKeys = {
+		$applicationCache: true,
+		$console: true,
+		$external: true,
+		$frame: true,
+		$frameElement: true,
+		$frames: true,
+		$innerHeight: true,
+		$innerWidth: true,
+		$onmozfullscreenchange: true,
+		$onmozfullscreenerror: true,
+		$outerHeight: true,
+		$outerWidth: true,
+		$pageXOffset: true,
+		$pageYOffset: true,
+		$parent: true,
+		$scrollLeft: true,
+		$scrollTop: true,
+		$scrollX: true,
+		$scrollY: true,
+		$self: true,
+		$webkitIndexedDB: true,
+		$webkitStorageInfo: true,
+		$window: true
+	};
+	var hasAutomationEqualityBug = (function () {
+		/* global window */
+		if (typeof window === 'undefined') { return false; }
+		for (var k in window) {
+			try {
+				if (!excludedKeys['$' + k] && has.call(window, k) && window[k] !== null && typeof window[k] === 'object') {
+					try {
+						equalsConstructorPrototype(window[k]);
+					} catch (e) {
+						return true;
+					}
+				}
+			} catch (e) {
+				return true;
+			}
 		}
-
-		// Detect buggy property enumeration order in older V8 versions.
-
-		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
-		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
-		test1[5] = 'de';
-		if (Object.getOwnPropertyNames(test1)[0] === '5') {
-			return false;
-		}
-
-		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
-		var test2 = {};
-		for (var i = 0; i < 10; i++) {
-			test2['_' + String.fromCharCode(i)] = i;
-		}
-		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
-			return test2[n];
-		});
-		if (order2.join('') !== '0123456789') {
-			return false;
-		}
-
-		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
-		var test3 = {};
-		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
-			test3[letter] = letter;
-		});
-		if (Object.keys(Object.assign({}, test3)).join('') !==
-				'abcdefghijklmnopqrst') {
-			return false;
-		}
-
-		return true;
-	} catch (err) {
-		// We don't expect any of the above to throw, but better to be safe.
 		return false;
-	}
-}
+	}());
+	var equalsConstructorPrototypeIfNotBuggy = function (o) {
+		/* global window */
+		if (typeof window === 'undefined' || !hasAutomationEqualityBug) {
+			return equalsConstructorPrototype(o);
+		}
+		try {
+			return equalsConstructorPrototype(o);
+		} catch (e) {
+			return false;
+		}
+	};
 
-module.exports = shouldUseNative() ? Object.assign : function (target, source) {
-	var from;
-	var to = toObject(target);
-	var symbols;
+	keysShim = function keys(object) {
+		var isObject = object !== null && typeof object === 'object';
+		var isFunction = toStr.call(object) === '[object Function]';
+		var isArguments = isArgs(object);
+		var isString = isObject && toStr.call(object) === '[object String]';
+		var theKeys = [];
 
-	for (var s = 1; s < arguments.length; s++) {
-		from = Object(arguments[s]);
+		if (!isObject && !isFunction && !isArguments) {
+			throw new TypeError('Object.keys called on a non-object');
+		}
 
-		for (var key in from) {
-			if (hasOwnProperty.call(from, key)) {
-				to[key] = from[key];
+		var skipProto = hasProtoEnumBug && isFunction;
+		if (isString && object.length > 0 && !has.call(object, 0)) {
+			for (var i = 0; i < object.length; ++i) {
+				theKeys.push(String(i));
 			}
 		}
 
-		if (getOwnPropertySymbols) {
-			symbols = getOwnPropertySymbols(from);
-			for (var i = 0; i < symbols.length; i++) {
-				if (propIsEnumerable.call(from, symbols[i])) {
-					to[symbols[i]] = from[symbols[i]];
+		if (isArguments && object.length > 0) {
+			for (var j = 0; j < object.length; ++j) {
+				theKeys.push(String(j));
+			}
+		} else {
+			for (var name in object) {
+				if (!(skipProto && name === 'prototype') && has.call(object, name)) {
+					theKeys.push(String(name));
 				}
 			}
 		}
-	}
 
-	return to;
+		if (hasDontEnumBug) {
+			var skipConstructor = equalsConstructorPrototypeIfNotBuggy(object);
+
+			for (var k = 0; k < dontEnums.length; ++k) {
+				if (!(skipConstructor && dontEnums[k] === 'constructor') && has.call(object, dontEnums[k])) {
+					theKeys.push(dontEnums[k]);
+				}
+			}
+		}
+		return theKeys;
+	};
+}
+module.exports = keysShim;
+
+},{"./isArguments":371}],370:[function(require,module,exports){
+'use strict';
+
+var slice = Array.prototype.slice;
+var isArgs = require('./isArguments');
+
+var origKeys = Object.keys;
+var keysShim = origKeys ? function keys(o) { return origKeys(o); } : require('./implementation');
+
+var originalKeys = Object.keys;
+
+keysShim.shim = function shimObjectKeys() {
+	if (Object.keys) {
+		var keysWorksWithArguments = (function () {
+			// Safari 5.0 bug
+			var args = Object.keys(arguments);
+			return args && args.length === arguments.length;
+		}(1, 2));
+		if (!keysWorksWithArguments) {
+			Object.keys = function keys(object) { // eslint-disable-line func-name-matching
+				if (isArgs(object)) {
+					return originalKeys(slice.call(object));
+				}
+				return originalKeys(object);
+			};
+		}
+	} else {
+		Object.keys = keysShim;
+	}
+	return Object.keys || keysShim;
 };
 
-},{}],362:[function(require,module,exports){
+module.exports = keysShim;
+
+},{"./implementation":369,"./isArguments":371}],371:[function(require,module,exports){
+'use strict';
+
+var toStr = Object.prototype.toString;
+
+module.exports = function isArguments(value) {
+	var str = toStr.call(value);
+	var isArgs = str === '[object Arguments]';
+	if (!isArgs) {
+		isArgs = str !== '[object Array]' &&
+			value !== null &&
+			typeof value === 'object' &&
+			typeof value.length === 'number' &&
+			value.length >= 0 &&
+			toStr.call(value.callee) === '[object Function]';
+	}
+	return isArgs;
+};
+
+},{}],372:[function(require,module,exports){
+'use strict';
+
+// modified from https://github.com/es-shims/es6-shim
+var objectKeys = require('object-keys');
+var hasSymbols = require('has-symbols/shams')();
+var callBound = require('call-bind/callBound');
+var toObject = Object;
+var $push = callBound('Array.prototype.push');
+var $propIsEnumerable = callBound('Object.prototype.propertyIsEnumerable');
+var originalGetSymbols = hasSymbols ? Object.getOwnPropertySymbols : null;
+
+// eslint-disable-next-line no-unused-vars
+module.exports = function assign(target, source1) {
+	if (target == null) { throw new TypeError('target must be an object'); }
+	var to = toObject(target); // step 1
+	if (arguments.length === 1) {
+		return to; // step 2
+	}
+	for (var s = 1; s < arguments.length; ++s) {
+		var from = toObject(arguments[s]); // step 3.a.i
+
+		// step 3.a.ii:
+		var keys = objectKeys(from);
+		var getSymbols = hasSymbols && (Object.getOwnPropertySymbols || originalGetSymbols);
+		if (getSymbols) {
+			var syms = getSymbols(from);
+			for (var j = 0; j < syms.length; ++j) {
+				var key = syms[j];
+				if ($propIsEnumerable(from, key)) {
+					$push(keys, key);
+				}
+			}
+		}
+
+		// step 3.a.iii:
+		for (var i = 0; i < keys.length; ++i) {
+			var nextKey = keys[i];
+			if ($propIsEnumerable(from, nextKey)) { // step 3.a.iii.2
+				var propValue = from[nextKey]; // step 3.a.iii.2.a
+				to[nextKey] = propValue; // step 3.a.iii.2.b
+			}
+		}
+	}
+
+	return to; // step 4
+};
+
+},{"call-bind/callBound":50,"has-symbols/shams":211,"object-keys":370}],373:[function(require,module,exports){
+'use strict';
+
+var implementation = require('./implementation');
+
+var lacksProperEnumerationOrder = function () {
+	if (!Object.assign) {
+		return false;
+	}
+	/*
+	 * v8, specifically in node 4.x, has a bug with incorrect property enumeration order
+	 * note: this does not detect the bug unless there's 20 characters
+	 */
+	var str = 'abcdefghijklmnopqrst';
+	var letters = str.split('');
+	var map = {};
+	for (var i = 0; i < letters.length; ++i) {
+		map[letters[i]] = letters[i];
+	}
+	var obj = Object.assign({}, map);
+	var actual = '';
+	for (var k in obj) {
+		actual += k;
+	}
+	return str !== actual;
+};
+
+var assignHasPendingExceptions = function () {
+	if (!Object.assign || !Object.preventExtensions) {
+		return false;
+	}
+	/*
+	 * Firefox 37 still has "pending exception" logic in its Object.assign implementation,
+	 * which is 72% slower than our shim, and Firefox 40's native implementation.
+	 */
+	var thrower = Object.preventExtensions({ 1: 2 });
+	try {
+		Object.assign(thrower, 'xy');
+	} catch (e) {
+		return thrower[1] === 'y';
+	}
+	return false;
+};
+
+module.exports = function getPolyfill() {
+	if (!Object.assign) {
+		return implementation;
+	}
+	if (lacksProperEnumerationOrder()) {
+		return implementation;
+	}
+	if (assignHasPendingExceptions()) {
+		return implementation;
+	}
+	return Object.assign;
+};
+
+},{"./implementation":372}],374:[function(require,module,exports){
+'use strict';
+
+/** @type {import('.')} */
+module.exports = [
+	'Float32Array',
+	'Float64Array',
+	'Int8Array',
+	'Int16Array',
+	'Int32Array',
+	'Uint8Array',
+	'Uint8ClampedArray',
+	'Uint16Array',
+	'Uint32Array',
+	'BigInt64Array',
+	'BigUint64Array'
+];
+
+},{}],375:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -99310,7 +99563,7 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],363:[function(require,module,exports){
+},{}],376:[function(require,module,exports){
 
 const toString = Object.prototype.toString;
 
@@ -99339,7 +99592,7 @@ module.exports = exports = function (regexp) {
 }
 
 
-},{}],364:[function(require,module,exports){
+},{}],377:[function(require,module,exports){
 /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
 /* eslint-disable node/no-deprecated-api */
 var buffer = require('buffer')
@@ -99406,7 +99659,7 @@ SafeBuffer.allocUnsafeSlow = function (size) {
   return buffer.SlowBuffer(size)
 }
 
-},{"buffer":49}],365:[function(require,module,exports){
+},{"buffer":49}],378:[function(require,module,exports){
 'use strict';
 
 var GetIntrinsic = require('get-intrinsic');
@@ -99414,12 +99667,10 @@ var define = require('define-data-property');
 var hasDescriptors = require('has-property-descriptors')();
 var gOPD = require('gopd');
 
-var $TypeError = GetIntrinsic('%TypeError%');
+var $TypeError = require('es-errors/type');
 var $floor = GetIntrinsic('%Math.floor%');
 
-/** @typedef {(...args: unknown[]) => unknown} Func */
-
-/** @type {<T extends Func = Func>(fn: T, length: number, loose?: boolean) => T} */
+/** @type {import('.')} */
 module.exports = function setFunctionLength(fn, length) {
 	if (typeof fn !== 'function') {
 		throw new $TypeError('`fn` is not a function');
@@ -99452,7 +99703,7 @@ module.exports = function setFunctionLength(fn, length) {
 	return fn;
 };
 
-},{"define-data-property":193,"get-intrinsic":198,"gopd":199,"has-property-descriptors":200}],366:[function(require,module,exports){
+},{"define-data-property":193,"es-errors/type":200,"get-intrinsic":206,"gopd":207,"has-property-descriptors":208}],379:[function(require,module,exports){
 
 /**
  * An Array.prototype.slice.call(arguments) alternative
@@ -99487,7 +99738,7 @@ module.exports = function (args, slice, sliceEnd) {
 }
 
 
-},{}],367:[function(require,module,exports){
+},{}],380:[function(require,module,exports){
 (function (setImmediate,clearImmediate){(function (){
 var nextTick = require('process/browser.js').nextTick;
 var apply = Function.prototype.apply;
@@ -99566,9 +99817,9 @@ exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate :
   delete immediateIds[id];
 };
 }).call(this)}).call(this,require("timers").setImmediate,require("timers").clearImmediate)
-},{"process/browser.js":362,"timers":367}],368:[function(require,module,exports){
+},{"process/browser.js":375,"timers":380}],381:[function(require,module,exports){
 arguments[4][24][0].apply(exports,arguments)
-},{"dup":24}],369:[function(require,module,exports){
+},{"dup":24}],382:[function(require,module,exports){
 // Currently in sync with Node.js lib/internal/util/types.js
 // https://github.com/nodejs/node/commit/112cc7c27551254aa2b17098fb774867f05ed0d9
 
@@ -99904,7 +100155,7 @@ exports.isAnyArrayBuffer = isAnyArrayBuffer;
   });
 });
 
-},{"is-arguments":208,"is-generator-function":212,"is-typed-array":214,"which-typed-array":371}],370:[function(require,module,exports){
+},{"is-arguments":216,"is-generator-function":220,"is-typed-array":222,"which-typed-array":384}],383:[function(require,module,exports){
 (function (process){(function (){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -100623,7 +100874,7 @@ function callbackify(original) {
 exports.callbackify = callbackify;
 
 }).call(this)}).call(this,require('_process'))
-},{"./support/isBuffer":368,"./support/types":369,"_process":362,"inherits":207}],371:[function(require,module,exports){
+},{"./support/isBuffer":381,"./support/types":382,"_process":375,"inherits":215}],384:[function(require,module,exports){
 (function (global){(function (){
 'use strict';
 
@@ -100633,6 +100884,7 @@ var callBind = require('call-bind');
 var callBound = require('call-bind/callBound');
 var gOPD = require('gopd');
 
+/** @type {(O: object) => string} */
 var $toString = callBound('Object.prototype.toString');
 var hasToStringTag = require('has-tostringtag/shams')();
 
@@ -100642,6 +100894,7 @@ var typedArrays = availableTypedArrays();
 var $slice = callBound('String.prototype.slice');
 var getPrototypeOf = Object.getPrototypeOf; // require('getprototypeof');
 
+/** @type {<T = unknown>(array: readonly T[], value: unknown) => number} */
 var $indexOf = callBound('Array.prototype.indexOf', true) || function indexOf(array, value) {
 	for (var i = 0; i < array.length; i += 1) {
 		if (array[i] === value) {
@@ -100650,17 +100903,23 @@ var $indexOf = callBound('Array.prototype.indexOf', true) || function indexOf(ar
 	}
 	return -1;
 };
+
+/** @typedef {(receiver: import('.').TypedArray) => string | typeof Uint8Array.prototype.slice.call | typeof Uint8Array.prototype.set.call} Getter */
+/** @type {{ [k in `\$${import('.').TypedArrayName}`]?: Getter } & { __proto__: null }} */
 var cache = { __proto__: null };
 if (hasToStringTag && gOPD && getPrototypeOf) {
 	forEach(typedArrays, function (typedArray) {
 		var arr = new g[typedArray]();
 		if (Symbol.toStringTag in arr) {
 			var proto = getPrototypeOf(arr);
+			// @ts-expect-error TS won't narrow inside a closure
 			var descriptor = gOPD(proto, Symbol.toStringTag);
 			if (!descriptor) {
 				var superProto = getPrototypeOf(proto);
+				// @ts-expect-error TS won't narrow inside a closure
 				descriptor = gOPD(superProto, Symbol.toStringTag);
 			}
+			// @ts-expect-error TODO: fix
 			cache['$' + typedArray] = callBind(descriptor.get);
 		}
 	});
@@ -100669,41 +100928,57 @@ if (hasToStringTag && gOPD && getPrototypeOf) {
 		var arr = new g[typedArray]();
 		var fn = arr.slice || arr.set;
 		if (fn) {
+			// @ts-expect-error TODO: fix
 			cache['$' + typedArray] = callBind(fn);
 		}
 	});
 }
 
+/** @type {(value: object) => false | import('.').TypedArrayName} */
 var tryTypedArrays = function tryAllTypedArrays(value) {
-	var found = false;
-	forEach(cache, function (getter, typedArray) {
-		if (!found) {
-			try {
-				if ('$' + getter(value) === typedArray) {
-					found = $slice(typedArray, 1);
-				}
-			} catch (e) { /**/ }
+	/** @type {ReturnType<typeof tryAllTypedArrays>} */ var found = false;
+	forEach(
+		// eslint-disable-next-line no-extra-parens
+		/** @type {Record<`\$${TypedArrayName}`, Getter>} */ /** @type {any} */ (cache),
+		/** @type {(getter: Getter, name: `\$${import('.').TypedArrayName}`) => void} */
+		function (getter, typedArray) {
+			if (!found) {
+				try {
+				// @ts-expect-error TODO: fix
+					if ('$' + getter(value) === typedArray) {
+						found = $slice(typedArray, 1);
+					}
+				} catch (e) { /**/ }
+			}
 		}
-	});
+	);
 	return found;
 };
 
+/** @type {(value: object) => false | import('.').TypedArrayName} */
 var trySlices = function tryAllSlices(value) {
-	var found = false;
-	forEach(cache, function (getter, name) {
-		if (!found) {
-			try {
-				getter(value);
-				found = $slice(name, 1);
-			} catch (e) { /**/ }
+	/** @type {ReturnType<typeof tryAllSlices>} */ var found = false;
+	forEach(
+		// eslint-disable-next-line no-extra-parens
+		/** @type {Record<`\$${TypedArrayName}`, Getter>} */ /** @type {any} */ (cache),
+		/** @type {(getter: typeof cache, name: `\$${import('.').TypedArrayName}`) => void} */ function (getter, name) {
+			if (!found) {
+				try {
+					// @ts-expect-error TODO: fix
+					getter(value);
+					found = $slice(name, 1);
+				} catch (e) { /**/ }
+			}
 		}
-	});
+	);
 	return found;
 };
 
+/** @type {import('.')} */
 module.exports = function whichTypedArray(value) {
 	if (!value || typeof value !== 'object') { return false; }
 	if (!hasToStringTag) {
+		/** @type {string} */
 		var tag = $slice($toString(value), 8, -1);
 		if ($indexOf(typedArrays, tag) > -1) {
 			return tag;
@@ -100719,4 +100994,4 @@ module.exports = function whichTypedArray(value) {
 };
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"available-typed-arrays":26,"call-bind":51,"call-bind/callBound":50,"for-each":195,"gopd":199,"has-tostringtag/shams":204}]},{},[1]);
+},{"available-typed-arrays":26,"call-bind":51,"call-bind/callBound":50,"for-each":203,"gopd":207,"has-tostringtag/shams":212}]},{},[1]);

--- a/lib/helpers/measure_helpers.js
+++ b/lib/helpers/measure_helpers.js
@@ -127,6 +127,9 @@ module.exports = class MeasureHelpers {
     emptyResultClauses,
     parentNode,
   ) {
+    // Nearly all ELM nodes now have a localId. We can no longer rely on the presence or lack of a localId to determine
+    // whether a node's localId should be collected.
+
     // Stop recursing if this node happens to be any TypeSpecifier. We do not want to collect localIds for these clauses
     // as they are not executed and will negatively affect clause coverage if captured here. ChoiceTypeSpecifiers do not
     // identify their type and instead put [] at the `type` attribute which is a deprecated field.
@@ -137,6 +140,9 @@ module.exports = class MeasureHelpers {
     ) {
       return localIds;
     }
+    // Stop recursing if this node represents the Patient obj since it is not part of coverage consideration.
+    if (statement.name && statement.name === 'Patient') return localIds;
+
     // looking at the key and value of everything on this object or array
     for (const k in statement) {
       let alId;
@@ -325,7 +331,8 @@ module.exports = class MeasureHelpers {
       } else if (k === 'localId') {
         localIds[v] = { localId: v };
         // if the value is an array or object, recurse
-      } else if (Array.isArray(v) || typeof v === 'object') {
+      } else if (Array.isArray(v)
+        || (typeof v === 'object' && k !== 'codes')) {
         this.findAllLocalIdsInStatement(
           v,
           libraryName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-execution",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "NPM module for calculating eCQMs (electronic clinical quality measures) written in CQL (clinical quality language).",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Newer Translator versions (~3.14.0 and newer) generate far more localIds across more nodes. Previously, we used the presence of a localId as a key input to whether a node's localId should be collected for coverage/highlighting consideration. This had automatically excluded unrelated nodes. Most notably, Patient obj and Terminology references such as a Data Element's filter.

This update skips ELM nodes representing the Patient obj and nodes containing terminology references. 

There may be other nodes that now get a localId that didn't previously that we will have to manually exclude.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
