### PR TITLE
Ignore isNull localId when immediately following a Not operator so that 'null' in 'not null' is not considered a unique clause.

### DIFF
--- a/lib/helpers/measure_helpers.js
+++ b/lib/helpers/measure_helpers.js
@@ -327,8 +327,15 @@ module.exports = class MeasureHelpers {
           localId: statement.localId,
           isFalsyLiteral: true,
         };
-        // else if the key is localId, push the value
+      // else if the key is localId, push the value
       } else if (k === 'localId') {
+        // skip IsNulls that immediately follow a Not operator so that users don't have to cover "null" when "not null" is covered.
+        if (statement.type && statement.type === 'IsNull'
+          && typeof parentNode === 'object'
+          && parentNode.type && parentNode.type === 'Not') {
+          // eslint-disable-next-line
+            continue; // skip the localId on this node.
+        }
         localIds[v] = { localId: v };
         // if the value is an array or object, recurse
       } else if (Array.isArray(v)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqm-execution",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "NPM module for calculating eCQMs (electronic clinical quality measures) written in CQL (clinical quality language).",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Pull requests into cqm-execution require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
